### PR TITLE
flatccrt: Fix CMake include-directory definition

### DIFF
--- a/flatccrt/CMakeLists.txt
+++ b/flatccrt/CMakeLists.txt
@@ -2,4 +2,4 @@ add_library(flatccrt STATIC IMPORTED GLOBAL)
 set_target_properties(flatccrt PROPERTIES 
     IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/lib/libflatccrt.a
 )
-target_include_directories(flatccrt INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set_target_properties(flatccrt PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
Fixes the following error at build time
```
...
-- Found PkgConfig: /opt/webos-sdk-x86_64/1.0.g/sysroots/x86_64-webossdk-linux/usr/bin/pkg-config (found version "0.29.1") 
-- Checking for module 'PmLogLib'
--   Found PmLogLib, version 3.3.0
-- Checking for module 'glib-2.0'
--   Found glib-2.0, version 2.48.2
CMake Error at flatccrt/CMakeLists.txt:5 (target_include_directories):
  Cannot specify include directories for imported target "flatccrt".


-- Checking for modules 'egl;glesv2'
--   Found egl, version 17.1.7
--   Found glesv2, version 17.1.7
-- Configuring incomplete, errors occurred!
See also "/home/runner/work/piccap/piccap/hyperion-webos/build/CMakeFiles/CMakeOutput.log".
Error: Process completed with exit code 1.
```