### PR TITLE
hyperion_client: prevent constant registration messages

### DIFF
--- a/src/hyperion_client.c
+++ b/src/hyperion_client.c
@@ -185,11 +185,7 @@ bool _parse_reply(hyperionnet_Reply_table_t reply)
         }
 
         // We got a registered reply.
-        if (registered == -1 || registered != _priority)
-        {
-            _registered = false;
-        }
-        else
+        if (registered == _priority)
         {
             _registered = true;
         }


### PR DESCRIPTION
hyperion client was sending a constant stream of registration messages
which would trigger buffer/heap overflows in hyperiond after a while.