### PR TITLE
backends/libdile_vt: use separate thread for vsync handling

### DIFF
--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -59,10 +59,12 @@ int capture_terminate() {
     }
     return 0;
 }
+
 int capture_cleanup() {
     DILE_VT_Destroy(vth);
     return 0;
 }
+
 int capture_start()
 {
     vth = DILE_VT_Create(0);
@@ -84,10 +86,11 @@ int capture_start()
     output_state.freezed = 0;
     output_state.appliedPQ = 0;
 
-    // I think we should probably find a better way of handling framerate
-    // division/counting. By default, divider of 1 will keep capture at around
-    // 45fps with default resolution.
-    output_state.framerate = 45 / config.fps;
+    // Framerate provided by libdile_vt is dependent on content currently played
+    // (50/60fps). We don't have any better way of limiting FPS, so let's just
+    // average it out - if someone sets their preferred framerate to 30 and
+    // content was 50fps, we'll just end up feeding 25 frames per second.
+    output_state.framerate = config.fps == 0 ? 1 : 60 / config.fps;
     fprintf(stderr, "[DILE_VT] framerate divider: %d\n", output_state.framerate);
 
     // Set framerate divider

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -18,6 +18,12 @@ cap_backend_config_t config = {0, 0, 0, 0};
 cap_imagedata_callback_t imagedata_cb = NULL;
 
 pthread_t capture_thread;
+pthread_t vsync_thread;
+
+pthread_mutex_t vsync_lock;
+pthread_cond_t vsync_cond;
+
+bool use_vsync_thread = true;
 bool capture_running = true;
 
 DILE_VT_HANDLE vth = NULL;
@@ -27,6 +33,7 @@ uint8_t* vfbs[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 int mem_fd = 0;
 
 void* capture_thread_target(void* data);
+void* vsync_thread_target(void* data);
 
 int capture_preinit(cap_backend_config_t *backend_config, cap_imagedata_callback_t callback)
 {
@@ -35,10 +42,21 @@ int capture_preinit(cap_backend_config_t *backend_config, cap_imagedata_callback
 
     return 0;
 }
-int capture_init() { return 0; }
+
+int capture_init() {
+    if (getenv("NO_VSYNC_THREAD") != NULL) {
+        use_vsync_thread = false;
+        fprintf(stderr, "[DILE_VT] Disabling vsync thread\n");
+    }
+    return 0;
+}
+
 int capture_terminate() {
     capture_running = false;
     pthread_join(capture_thread, NULL);
+    if (use_vsync_thread) {
+        pthread_join(vsync_thread, NULL);
+    }
     return 0;
 }
 int capture_cleanup() {
@@ -70,6 +88,7 @@ int capture_start()
     // division/counting. By default, divider of 1 will keep capture at around
     // 45fps with default resolution.
     output_state.framerate = 45 / config.fps;
+    fprintf(stderr, "[DILE_VT] framerate divider: %d\n", output_state.framerate);
 
     // Set framerate divider
     if (DILE_VT_SetVideoFrameOutputDeviceState(vth, DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_STATE_FRAMERATE_DIVIDE, &output_state) != 0) {
@@ -86,24 +105,55 @@ int capture_start()
         return -6;
     }
 
-    if (pthread_create( &capture_thread, NULL, capture_thread_target, NULL) != 0) {
+    if (pthread_create (&capture_thread, NULL, capture_thread_target, NULL) != 0) {
         return -7;
+    }
+
+    if (use_vsync_thread) {
+        if (pthread_create (&vsync_thread, NULL, vsync_thread_target, NULL) != 0) {
+            return -8;
+        }
     }
 }
 
+uint64_t framecount = 0;
+uint64_t start_time = 0;
+uint64_t getticks_us()
+{
+    struct timespec tp;
+    clock_gettime(CLOCK_MONOTONIC, &tp);
+    return tp.tv_sec * 1000000 + tp.tv_nsec / 1000;
+}
+
+uint32_t idx = 0;
+
 void capture_frame() {
-    uint32_t idx = 0;
     uint32_t* ptrs[32] = {0}; // FIXME: this is obviously wrong??
     uint32_t** p1 = &ptrs;
     DILE_VT_FRAMEBUFFER_PROPERTY vfbprop;
     vfbprop.ptr = &p1;
 
-    DILE_VT_WaitVsync(vth, 0, 0);
+    if (use_vsync_thread) {
+        pthread_mutex_lock(&vsync_lock);
+        pthread_cond_wait(&vsync_cond, &vsync_lock);
+        pthread_mutex_unlock(&vsync_lock);
+    } else {
+        DILE_VT_WaitVsync(vth, 0, 0);
+    }
 
     output_state.freezed = 1;
     DILE_VT_SetVideoFrameOutputDeviceState(vth, DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_STATE_FREEZED, &output_state);
 
     DILE_VT_GetCurrentVideoFrameBufferProperty(vth, &vfbprop, &idx);
+
+    uint64_t now = getticks_us();
+    if (framecount % 30 == 0) {
+        fprintf(stderr, "[DILE_VT] pixel format: %d; width: %d; height: %d; stride: %d\n", vfbprop.pixelFormat, vfbprop.width, vfbprop.height, vfbprop.stride);
+        fprintf(stderr, "[DILE_VT] framerate: %.6f FPS\n", (30.0 * 1000000) / (now - start_time));
+        start_time = now;
+    }
+
+    framecount += 1;
 
     if (idx < 16) {
         if (vfbs[idx] == 0)
@@ -120,5 +170,14 @@ void capture_frame() {
 void* capture_thread_target(void* data) {
     while (capture_running) {
         capture_frame();
+    }
+}
+
+void* vsync_thread_target(void* data) {
+    while (capture_running) {
+        DILE_VT_WaitVsync(vth, 0, 0);
+        pthread_mutex_lock(&vsync_lock);
+        pthread_cond_signal(&vsync_cond);
+        pthread_mutex_unlock(&vsync_lock);
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -40,7 +40,7 @@ static const char *_backend = NULL;
 static const char *_address = NULL;
 static int _port = 19400;
 
-static cap_backend_config_t config = {15, 0, 192, 108};
+static cap_backend_config_t config = {0, 0, 192, 108};
 static cap_backend_funcs_t backend = {NULL};
 
 static int image_data_cb(int width, int height, uint8_t *rgb_data);
@@ -104,7 +104,7 @@ static void print_usage()
     printf("  -y, --height=HEIGHT   Height of video frame (default 108)\n");
     printf("  -a, --address=ADDR    IP address of Hyperion server\n");
     printf("  -p, --port=PORT       Port of Hyperion flatbuffers server (default 19400)\n");
-    printf("  -f, --fps=FPS         Framerate for sending video frames (default 15)\n");
+    printf("  -f, --fps=FPS         Framerate for sending video frames (default 0 = unlimited)\n");
     printf("  -b, --backend=BE      Use specific backend (default auto)\n");
     printf("  -V, --no-video        Video will not be captured\n");
     printf("  -G, --no-gui          GUI/UI will not be captured\n");


### PR DESCRIPTION
This lets us increase framerates from ~50 to ~60 FPS (or 40 to 50) when framerate divider is set to 1.
Seems to work fairly well, but needs testing.

`NO_VSYNC_THREAD` environment variable can be set for testing purposes.

This behaviour is similar to what `libvt` does internally - they spawn a thread that just waits for vsync and dispatches "texture ready" events, which is then handled in a separate/main thread when calling `VT_GenerateTexture`, so should be fairly safe.