### PR TITLE
libdile_vt: don't overwrite resolution when reaching scaledown limits

### DIFF
--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -108,9 +108,7 @@ int capture_start()
     DILE_VT_RECT region = {0, 0, config.resolution_width, config.resolution_height};
 
     if (region.width < limitation.scaleDownLimitWidth || region.height < limitation.scaleDownLimitHeight) {
-        fprintf(stderr, "[DILE_VT] scaledown limit, overriding to %dx%d\n", limitation.scaleDownLimitWidth, limitation.scaleDownLimitHeight);
-        region.width = limitation.scaleDownLimitWidth;
-        region.height = limitation.scaleDownLimitHeight;
+        fprintf(stderr, "[DILE_VT] WARNING: scaledown is limited to %dx%d while %dx%d has been chosen - there's a chance this will crash!\n", limitation.scaleDownLimitWidth, limitation.scaleDownLimitHeight, region.width, region.height);
     }
 
     if (DILE_VT_SetVideoFrameOutputDeviceOutputRegion(vth, DILE_VT_DISPLAY_OUTPUT, &region) != 0) {


### PR DESCRIPTION
Seems like this value is misreported on some devices as 320x240, while
resolutions like 192x108 are properly supported with much higher
framerate.

Let's just leave it as a warning now and add a force flag later (or
report this properly in UI)

Fixes #15 