### PR TITLE
dile_vt: GM blending

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ add_library(dile_vt_backend SHARED
 
 target_compile_definitions(dile_vt_backend PRIVATE CAPTURE_BACKEND)
 target_include_directories(dile_vt_backend PRIVATE src src/backends)
-target_link_libraries(dile_vt_backend dile_vt yuv)
+target_link_libraries(dile_vt_backend dile_vt gm yuv)
 
 # libdile_vt.so seems to be missing DT_NEEDED for libPmLogLib.so.3 - let's just
 # add it over to our library. For some reason adding PmLogLib loaded via

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ webOS versions/hardware platforms.
 
 | Backend        | Description                                                                                    | Video | UI | Framerate | webOS |
 |----------------|------------------------------------------------------------------------------------------------|-------|----|-----------|-------|
-| `libdile_vt`   | Low-level library used internally by libvt                                                     |   ✔   | ✘¹ | 60        | 3.x+ |
-| `libvt`        | High-level video rendering library, uses OpenGL, may cause flickering/"No signal" until reboot |   ✔   | ✘¹ | ~30       | 3.x+ |
+| `libdile_vt`   | Low-level library used internally by libvt                                                     |   ✔   | ✔  | 60        | 3.x-5.x |
+| `libvt`        | High-level video rendering library, uses OpenGL, may cause flickering/"No signal" until reboot |   ✔   | ✘¹ | ~30       | 3.x-5.x |
 | `libvtcapture` | High-level video capture library, uses Luna bus, could possibly work without root (not now)    |   ✔   | ✔  | ~25       | 5.x+ |
 
 ¹ - UI capture could be added at some point in the future

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -83,7 +83,9 @@ int capture_terminate() {
         pthread_join(vsync_thread, NULL);
     }
 
-    GM_DestroySurface(gm_surface.surfaceID);
+    if (!config.no_gui) {
+        GM_DestroySurface(gm_surface.surfaceID);
+    }
 
     DILE_VT_Stop(vth);
 
@@ -199,7 +201,7 @@ int capture_start()
         }
     }
 
-    if (GM_CreateSurface(region.width, region.height, 0, &gm_surface) != 0) {
+    if (!config.no_gui && GM_CreateSurface(region.width, region.height, 0, &gm_surface) != 0) {
         return -13;
     }
 
@@ -332,7 +334,7 @@ void capture_frame() {
     t7 = getticks_us();
 
     if ((framecount % 15 == 0) && config.verbose) {
-        fprintf(stderr, "[DILE_VT] frame feed time: %.3fms\n", (t7 - t1) / 1000);
+        PmLogInfo(logcontext, "DILECPTFRM", 0, "[DILE_VT] frame feed time: %.3fms", (t7 - t1) / 1000);
     }
 
     output_state.freezed = 0;

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -235,10 +235,10 @@ void dump_buffer(uint8_t* buf, uint64_t size, uint32_t idx, uint32_t plane) {
 }
 
 void capture_frame() {
-    static uint8_t* outbuf = NULL;
     uint16_t t1,t7;
     uint32_t width = vfbprop.width;
     uint32_t height = vfbprop.height;
+    static uint8_t* outbuf = NULL;
     static uint8_t* argbvideo = NULL;
     static uint8_t* argbblended = NULL;
     static uint8_t* argbui = NULL;

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -238,6 +238,7 @@ void capture_frame() {
     uint16_t t1,t7;
     uint32_t width = vfbprop.width;
     uint32_t height = vfbprop.height;
+
     static uint8_t* outbuf = NULL;
     static uint8_t* argbvideo = NULL;
     static uint8_t* argbblended = NULL;
@@ -265,23 +266,26 @@ void capture_frame() {
     framecount += 1;
 
     if (vfbprop.pixelFormat == DILE_VT_VIDEO_FRAME_BUFFER_PIXEL_FORMAT_RGB) {
+        // Width is incorrectly reported on RGB pixel format (equal to stride)
+        width = vfbprop.stride / 3;
+
         t1 = getticks_us();
         if (config.no_gui) {
             outbuf = vfbs[idx][0];
         } else {
             if (outbuf == NULL)
-                outbuf = malloc(3 * width * height); // Temporary conversion buffer
+                outbuf = malloc(3 * width * height);
 
             if (config.no_video) {
                 GM_CaptureGraphicScreen(gm_surface.surfaceID, &width, &height);
                 ABGRToRGB24(gm_surface.framebuffer, 4 * width, outbuf, 3 * width, width, height);
             } else {
                 if (argbui == NULL)
-                    argbui = malloc(3 * width * height);
+                    argbui = malloc(4 * width * height);
                 if (argbvideo == NULL)
-                    argbvideo = malloc(3 * width * height);
+                    argbvideo = malloc(4 * width * height);
                 if (argbblended == NULL)
-                    argbblended = malloc(3 * width * height);
+                    argbblended = malloc(4 * width * height);
 
                 GM_CaptureGraphicScreen(gm_surface.surfaceID, &width, &height);
                 ABGRToARGB(gm_surface.framebuffer, 4 * width, argbui, 4 * width, width, height);
@@ -292,7 +296,7 @@ void capture_frame() {
         }
     } else if (vfbprop.pixelFormat == DILE_VT_VIDEO_FRAME_BUFFER_PIXEL_FORMAT_YUV420_SEMI_PLANAR) {
         if (outbuf == NULL)
-            outbuf = malloc (width * height * 3); // Temporary conversion buffer
+            outbuf = malloc(3 * width * height);
 
         if (config.no_gui) {
             t1 = getticks_us();
@@ -303,11 +307,11 @@ void capture_frame() {
             ABGRToRGB24(gm_surface.framebuffer, 4 * width, outbuf, 3 * width, width, height);
         } else {
             if (argbvideo == NULL)
-                argbvideo = malloc(3 * width * height);
+                argbvideo = malloc(4 * width * height);
             if (argbblended == NULL)
-                argbblended = malloc(3 * width * height);
+                argbblended = malloc(4 * width * height);
             if (argbui == NULL)
-                argbui = malloc(3 * width * height);
+                argbui = malloc(4 * width * height);
 
             t1 = getticks_us();
             GM_CaptureGraphicScreen(gm_surface.surfaceID, &width, &height);

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -11,6 +11,7 @@
 
 #include <libyuv.h>
 #include <dile_vt.h>
+#include <gm.h>
 
 #include "common.h"
 #include <PmLogLib.h>
@@ -35,6 +36,8 @@ DILE_VT_HANDLE vth = NULL;
 DILE_OUTPUTDEVICE_STATE output_state;
 DILE_VT_FRAMEBUFFER_PROPERTY vfbprop;
 DILE_VT_FRAMEBUFFER_CAPABILITY vfbcap;
+
+GM_SURFACE gm_surface;
 
 uint8_t*** vfbs;
 int mem_fd = 0;
@@ -79,6 +82,8 @@ int capture_terminate() {
     if (use_vsync_thread && vsync_thread != NULL) {
         pthread_join(vsync_thread, NULL);
     }
+
+    GM_DestroySurface(gm_surface.surfaceID);
 
     DILE_VT_Stop(vth);
 
@@ -194,6 +199,10 @@ int capture_start()
         }
     }
 
+    if (GM_CreateSurface(region.width, region.height, 0, &gm_surface) != 0) {
+        return -13;
+    }
+
     if (DILE_VT_Start(vth) != 0) {
        return -12;
     }
@@ -215,6 +224,15 @@ int capture_start()
 uint64_t framecount = 0;
 uint64_t start_time = 0;
 uint32_t idx = 0;
+
+void dump_buffer(uint8_t* buf, uint64_t size, uint32_t idx, uint32_t plane) {
+    char filename[256];
+    snprintf(filename, sizeof(filename), "/tmp/hyperion-webos-dump.%03d.%03d.raw", idx, plane);
+    FILE* fd = fopen(filename, "wb");
+    fwrite(buf, size, 1, fd);
+    fclose(fd);
+    PmLogInfo(logcontext, "DILEDUMP", 0, "Buffer dumped to: %s", filename);
+}
 
 void capture_frame() {
     static uint8_t* outbuf = NULL;
@@ -243,7 +261,45 @@ void capture_frame() {
 
     if (vfbprop.pixelFormat == DILE_VT_VIDEO_FRAME_BUFFER_PIXEL_FORMAT_RGB) {
         // Note: vfbprop.width is equal to stride for some reason.
-        imagedata_cb(vfbprop.stride / 3, vfbprop.height, vfbs[idx][0]);
+        uint32_t width = vfbprop.stride / 3;
+        uint32_t height = vfbprop.height;
+
+        uint32_t gmwidth = width;
+        uint32_t gmheight = height;
+
+        static uint8_t* argbvideo = NULL;
+        static uint8_t* argbblended = NULL;
+        static uint8_t* argbui = NULL;
+
+        if (argbvideo == NULL) {
+            argbvideo = malloc(4 * width * height);
+        }
+
+        if (argbblended == NULL) {
+            argbblended = malloc(4 * width * height);
+        }
+
+        if (argbui == NULL) {
+            argbui = malloc(4 * width * height);
+        }
+
+        if (outbuf == NULL) {
+            // Temporary conversion buffer
+            outbuf = malloc(3 * width * height);
+        }
+
+        uint64_t t1 = getticks_us();
+        GM_CaptureGraphicScreen(gm_surface.surfaceID, &gmwidth, &gmheight);
+        ABGRToARGB(gm_surface.framebuffer, 4 * width, argbui, 4 * width, width, height);
+        RGB24ToARGB(vfbs[idx][0], vfbprop.stride, argbvideo, 4 * width, width, height);
+        ARGBBlend(argbui, 4 * width, argbvideo, 4 * width, argbblended, 4 * width, width, height);
+        ARGBToRGB24(argbblended, 4 * width, outbuf, 3 * width, width, height);
+        imagedata_cb(width, height, outbuf);
+        uint64_t t7 = getticks_us();
+
+        if (framecount % 15 == 0) {
+            PmLogInfo(logcontext, "DILECPTFRM", 0, "[DILE_VT] Frame feed time: %.3fms",  (t7 - t1) / 1000.0);
+        }
     } else if (vfbprop.pixelFormat == DILE_VT_VIDEO_FRAME_BUFFER_PIXEL_FORMAT_YUV420_SEMI_PLANAR) {
         if (outbuf == NULL) {
             // Temporary conversion buffer
@@ -255,12 +311,7 @@ void capture_frame() {
     } else {
         PmLogError(logcontext, "DILECPTFRM", 0, "[DILE_VT] Unsupported pixel format: %d", vfbprop.pixelFormat);
         for (int plane = 0; plane < vfbcap.numPlanes; plane++) {
-            char filename[256];
-            snprintf(filename, sizeof(filename), "/tmp/hyperion-webos-dump.%03d.%03d.raw", idx, plane);
-            FILE* fd = fopen(filename, "wb");
-            fwrite(vfbs[idx][plane], vfbprop.stride * vfbprop.height, 1, fd);
-            fclose(fd);
-            PmLogError(logcontext, "DILECPTFRM", 0, "[DILE_VT] Dumped buffer to: %s", filename);
+            dump_buffer(vfbs[idx][plane], vfbprop.stride * vfbprop.height, idx, plane);
         }
     }
 

--- a/src/common.h
+++ b/src/common.h
@@ -22,6 +22,7 @@ typedef struct _cap_backend_config {
     bool save_config;
     bool load_config;
     bool no_service;
+    bool verbose;
 } cap_backend_config_t;
 
 #if defined(CAPTURE_BACKEND)

--- a/src/main.c
+++ b/src/main.c
@@ -42,6 +42,7 @@ static struct option long_options[] = {
     {"no-video", no_argument, 0, 'V'},
     {"no-gui", no_argument, 0, 'G'},
     {"no-service", no_argument, 0, 'S'},
+    {"verbose", no_argument, 0, 'v'},
     {"backend", required_argument, 0, 'b'},
     {"help", no_argument, 0, 'h'},
     {"config", required_argument, 0, 'c'},
@@ -334,7 +335,7 @@ static void print_usage()
     printf("  -G, --no-gui          GUI/UI will not be captured\n");
     printf("  -c, --config=PATH     Absolute path for configfile to load settings. Giving additional runtime arguments will overwrite loaded ones.\n");
     printf("  -s, --save-conf=PATH  Saving configfile to given path.\n");
-    
+    printf("  -v, --verbose         Verbose logging\n");
 }
 
 static int parse_options(int argc, char *argv[])
@@ -345,7 +346,7 @@ static int parse_options(int argc, char *argv[])
         PmLogError(logcontext, "FNCPARSEOPT", 0, "Error while setting default settings!");
     }
     int opt, longindex;
-    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:h:c:s:SVG", long_options, &longindex)) != -1)
+    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:h:c:s:SVGv", long_options, &longindex)) != -1)
     {
         switch (opt)
         {
@@ -372,6 +373,8 @@ static int parse_options(int argc, char *argv[])
             break;
         case 'S':
             config.no_service = 1;
+        case 'v':
+            config.verbose = 1;
             break;
         case 'b':
             _backend = strdup(optarg);


### PR DESCRIPTION
Initial implementation of UI layer blending in dile_vt, based on libyuv routines.

On K3LP / webOS 3.8 I got these findings:
* GM is not able to go down to 192x108, lowest working resolution here is 240x135.
* Approximate frame processing times starts at around 13ms, but then, after ~15 seconds, settles around 9-10ms. This means we can *barely* manage steady 60fps if we count in normal system CPU usage spikes. Seems like we are mostly limited by graphics memory access? See metrics below. *Maybe* we could split this up into multiple threads, but I don't have any common sense regarding these kinds of optimizations.

We likely want to *also* detect if the video is actually on-screen (there was a DILE_VT call for that...) and then drop whole alpha blending step.

Timings breakdown for some sample run:
```
GM_CaptureGraphicScreen: 2507us
ABGRToARGB from GM to malloced memory: 3667us
RGB24ToARGB from VFB to malloced memory: 2953us
ARGBBlend: 222us
ARGBToRGB24: 136us
Hyperion callback: 890us
```

This now also implement `--no-video`, `--no-gui`, and support for blending on `pixelFormat 1`, thanks to #25. To be merged after #24 