### PR TITLE
Logging refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,12 @@ pkg_check_modules(GLESv2 glesv2 REQUIRED)
 
 add_executable(hyperion-webos
     src/main.c
+    src/log.c
     src/hyperion_client.c
  )
 target_include_directories(hyperion-webos PRIVATE fbs)
 target_link_libraries(hyperion-webos flatccrt pthread dl ${GTHREAD2_LDFLAGS} ${PBNJSON_LDFLAGS} ${LS2_LDFLAGS} ${GLIB2_LDFLAGS} ${PMLOG_LDFLAGS})
+set_property(TARGET hyperion-webos PROPERTY ENABLE_EXPORTS 1)
 
 # Backends
 add_library(vt_backend SHARED

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -13,9 +13,7 @@
 #include <dile_vt.h>
 
 #include "common.h"
-#include <PmLogLib.h>
-#include <glib.h>
-#include <glib-object.h>
+#include "log.h"
 
 cap_backend_config_t config = {0, 0, 0, 0};
 cap_imagedata_callback_t imagedata_cb = NULL;
@@ -28,8 +26,6 @@ pthread_cond_t vsync_cond;
 
 bool use_vsync_thread = true;
 bool capture_running = true;
-
-PmLogContext logcontext;
 
 DILE_VT_HANDLE vth = NULL;
 DILE_OUTPUTDEVICE_STATE output_state;
@@ -51,8 +47,7 @@ uint64_t getticks_us()
 
 int capture_preinit(cap_backend_config_t *backend_config, cap_imagedata_callback_t callback)
 {
-    PmLogGetContext("hyperion-webos_service", &logcontext);
-    PmLogInfo(logcontext, "DILEPREINIT", 0, "Preinit called. Copying config..");
+    INFO("Preinit called. Copying config..");
     memcpy(&config, backend_config, sizeof(cap_backend_config_t));
     imagedata_cb = callback;
 
@@ -60,16 +55,17 @@ int capture_preinit(cap_backend_config_t *backend_config, cap_imagedata_callback
 }
 
 int capture_init() {
-    PmLogInfo(logcontext, "DILEINIT", 0, "Init called.");
+    INFO("Init called");
     if (getenv("NO_VSYNC_THREAD") != NULL) {
         use_vsync_thread = false;
-        PmLogError(logcontext, "DILECPTINIT", 0, "[DILE_VT] Disabling vsync thread");
+        WARN("Disabling vsync thread");
     }
     return 0;
 }
 
 int capture_terminate() {
-    PmLogInfo(logcontext, "DILETERM", 0, "Capture termination called.");
+    INFO("Capture termination called");
+
     capture_running = false;
 
     if (capture_thread != NULL) {
@@ -94,7 +90,7 @@ int capture_cleanup() {
 
 int capture_start()
 {
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "Capture start called.");
+    INFO("Capture start called.");
     vth = DILE_VT_Create(0);
     if (vth == NULL) {
         return -1;
@@ -105,10 +101,10 @@ int capture_start()
         return -11;
     }
 
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "[DILE_VT] supportScaleUp: %d; (%dx%d)", limitation.supportScaleUp, limitation.scaleUpLimitWidth, limitation.scaleUpLimitHeight);
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "[DILE_VT] supportScaleDown: %d; (%dx%d)", limitation.supportScaleDown, limitation.scaleDownLimitWidth, limitation.scaleDownLimitHeight);
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "[DILE_VT] maxResolution: %dx%d", limitation.maxResolution.width, limitation.maxResolution.height);
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "[DILE_VT] input deinterlace: %d; display deinterlace: %d", limitation.supportInputVideoDeInterlacing, limitation.supportDisplayVideoDeInterlacing);
+    DBG("supportScaleUp: %d; (%dx%d)", limitation.supportScaleUp, limitation.scaleUpLimitWidth, limitation.scaleUpLimitHeight);
+    DBG("supportScaleDown: %d; (%dx%d)", limitation.supportScaleDown, limitation.scaleDownLimitWidth, limitation.scaleDownLimitHeight);
+    DBG("maxResolution: %dx%d", limitation.maxResolution.width, limitation.maxResolution.height);
+    DBG("input deinterlace: %d; display deinterlace: %d", limitation.supportInputVideoDeInterlacing, limitation.supportDisplayVideoDeInterlacing);
 
     if (DILE_VT_SetVideoFrameOutputDeviceDumpLocation(vth, DILE_VT_DISPLAY_OUTPUT) != 0) {
         return -2;
@@ -117,7 +113,7 @@ int capture_start()
     DILE_VT_RECT region = {0, 0, config.resolution_width, config.resolution_height};
 
     if (region.width < limitation.scaleDownLimitWidth || region.height < limitation.scaleDownLimitHeight) {
-        PmLogError(logcontext, "DILECPTSTART", 0, "[DILE_VT] WARNING: scaledown is limited to %dx%d while %dx%d has been chosen - there's a chance this will crash!", limitation.scaleDownLimitWidth, limitation.scaleDownLimitHeight, region.width, region.height);
+        WARN("scaledown is limited to %dx%d while %dx%d has been chosen - there's a chance this will crash!", limitation.scaleDownLimitWidth, limitation.scaleDownLimitHeight, region.width, region.height);
     }
 
     if (DILE_VT_SetVideoFrameOutputDeviceOutputRegion(vth, DILE_VT_DISPLAY_OUTPUT, &region) != 0) {
@@ -133,7 +129,7 @@ int capture_start()
     // average it out - if someone sets their preferred framerate to 30 and
     // content was 50fps, we'll just end up feeding 25 frames per second.
     output_state.framerate = config.fps == 0 ? 1 : 60 / config.fps;
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "[DILE_VT] framerate divider: %d", output_state.framerate);
+    INFO("[DILE_VT] framerate divider: %d", output_state.framerate);
 
     DILE_VT_WaitVsync(vth, 0, 0);
     uint64_t t1 = getticks_us();
@@ -141,7 +137,7 @@ int capture_start()
     uint64_t t2 = getticks_us();
 
     double fps = 1000000.0 / (t2 - t1);
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "[DILE_VT] frametime: %d; estimated fps before divider: %.5f", t2 - t1, fps);
+    INFO("[DILE_VT] frametime: %d; estimated fps before divider: %.5f", t2 - t1, fps);
 
     // Set framerate divider
     if (DILE_VT_SetVideoFrameOutputDeviceState(vth, DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_STATE_FRAMERATE_DIVIDE, &output_state) != 0) {
@@ -154,7 +150,7 @@ int capture_start()
     t2 = getticks_us();
 
     fps = 1000000.0 / (t2 - t1);
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "[DILE_VT] frametime: %d; estimated fps after divider: %.5f", t2 - t1, fps);
+    INFO("[DILE_VT] frametime: %d; estimated fps after divider: %.5f", t2 - t1, fps);
 
     // Set freeze
     if (DILE_VT_SetVideoFrameOutputDeviceState(vth, DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_STATE_FREEZED, &output_state) != 0) {
@@ -166,7 +162,7 @@ int capture_start()
         return -9;
     }
 
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "[DILE_VT] vfbs: %d; planes: %d", vfbcap.numVfbs, vfbcap.numPlanes);
+    INFO("[DILE_VT] vfbs: %d; planes: %d", vfbcap.numVfbs, vfbcap.numPlanes);
     uint32_t** ptr = calloc(sizeof(uint32_t*), vfbcap.numVfbs);
     for (int vfb = 0; vfb < vfbcap.numVfbs; vfb++) {
         ptr[vfb] = calloc(sizeof(uint32_t), vfbcap.numPlanes);
@@ -184,12 +180,12 @@ int capture_start()
         return -6;
     }
 
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "DILECPTSTART", 0, "[DILE_VT] pixelFormat: %d; width: %d; height: %d; stride: %d...", vfbprop.pixelFormat, vfbprop.width, vfbprop.height, vfbprop.stride);
+    INFO("[DILE_VT] pixelFormat: %d; width: %d; height: %d; stride: %d...", vfbprop.pixelFormat, vfbprop.width, vfbprop.height, vfbprop.stride);
     vfbs = calloc(vfbcap.numVfbs, sizeof(uint8_t**));
     for (int vfb = 0; vfb < vfbcap.numVfbs; vfb++) {
         vfbs[vfb] = calloc(vfbcap.numPlanes, sizeof(uint8_t*));
         for (int plane = 0; plane < vfbcap.numPlanes; plane++) {
-            PmLogError(logcontext, "DILECPTSTART", 0, "[DILE_VT] vfb[%d][%d] = 0x%08x", vfb, plane, vfbprop.ptr[vfb][plane]);
+            DBG("[DILE_VT] vfb[%d][%d] = 0x%08x", vfb, plane, vfbprop.ptr[vfb][plane]);
             vfbs[vfb][plane] = (uint8_t*) mmap(0, vfbprop.stride * vfbprop.height, PROT_READ, MAP_SHARED, mem_fd, vfbprop.ptr[vfb][plane]);
         }
     }
@@ -209,12 +205,21 @@ int capture_start()
             return -8;
         }
     }
-    PmLogInfo(logcontext, "DILECPTSTART", 0, "Capture finished.");
+    INFO("Capture finished.");
 }
 
 uint64_t framecount = 0;
 uint64_t start_time = 0;
 uint32_t idx = 0;
+
+void dump_buffer(uint8_t* buf, uint64_t size, uint32_t idx, uint32_t plane) {
+    char filename[256];
+    snprintf(filename, sizeof(filename), "/tmp/hyperion-webos-dump.%03d.%03d.raw", idx, plane);
+    FILE* fd = fopen(filename, "wb");
+    fwrite(buf, size, 1, fd);
+    fclose(fd);
+    INFO("Buffer dumped to: %s", filename);
+}
 
 void capture_frame() {
     static uint8_t* outbuf = NULL;
@@ -234,7 +239,7 @@ void capture_frame() {
 
     uint64_t now = getticks_us();
     if (framecount % 30 == 0) {
-        PmLogError(logcontext, "DILECPTFRM", 0, "[DILE_VT] framerate: %.6f FPS", (30.0 * 1000000) / (now - start_time));
+        DBG("framerate: %.6f FPS", (30.0 * 1000000) / (now - start_time));
         start_time = now;
     }
 
@@ -253,15 +258,18 @@ void capture_frame() {
         NV21ToRGB24(vfbs[idx][0], vfbprop.stride, vfbs[idx][1], vfbprop.stride, outbuf, vfbprop.width * 3, vfbprop.width, vfbprop.height);
         imagedata_cb(vfbprop.width, vfbprop.height, outbuf);
     } else {
-        PmLogError(logcontext, "DILECPTFRM", 0, "[DILE_VT] Unsupported pixel format: %d", vfbprop.pixelFormat);
+        ERR("[DILE_VT] Unsupported pixel format: %d", vfbprop.pixelFormat);
         for (int plane = 0; plane < vfbcap.numPlanes; plane++) {
-            char filename[256];
-            snprintf(filename, sizeof(filename), "/tmp/hyperion-webos-dump.%03d.%03d.raw", idx, plane);
-            FILE* fd = fopen(filename, "wb");
-            fwrite(vfbs[idx][plane], vfbprop.stride * vfbprop.height, 1, fd);
-            fclose(fd);
-            PmLogError(logcontext, "DILECPTFRM", 0, "[DILE_VT] Dumped buffer to: %s", filename);
+            dump_buffer(vfbs[idx][plane], vfbprop.stride * vfbprop.height, idx, plane);
         }
+        return;
+    }
+
+    imagedata_cb(width, height, outbuf);
+    t7 = getticks_us();
+
+    if (framecount % 15 == 0) {
+        DBG("[DILE_VT] frame feed time: %.3fms", (t7 - t1) / 1000);
     }
 
     output_state.freezed = 0;
@@ -269,14 +277,14 @@ void capture_frame() {
 }
 
 void* capture_thread_target(void* data) {
-    PmLogInfo(logcontext, "DILECPTTHREAD", 0, "capture_thread_target called.");
+    INFO("capture_thread_target called.");
     while (capture_running) {
         capture_frame();
     }
 }
 
 void* vsync_thread_target(void* data) {
-    PmLogInfo(logcontext, "DILEVSYNCTHREAD", 0, "vsync_thread_target called.");
+    INFO("vsync_thread_target called.");
     while (capture_running) {
         DILE_VT_WaitVsync(vth, 0, 0);
         pthread_mutex_lock(&vsync_lock);

--- a/src/common.h
+++ b/src/common.h
@@ -22,6 +22,7 @@ typedef struct _cap_backend_config {
     bool save_config;
     bool load_config;
     bool no_service;
+    bool verbose;
 } cap_backend_config_t;
 
 #if defined(CAPTURE_BACKEND)

--- a/src/log.c
+++ b/src/log.c
@@ -47,7 +47,7 @@ void log_printf(LogLevel level, const char* module, const char* fmt, ...) {
 
     char formatted[1024];
     vsnprintf(formatted, 1024, fmt, args);
-    _PmLogMsgKV(context, level, 0, module, 0, NULL, NULL, formatted);
+    _PmLogMsgKV(context, level, 0, level == Debug ? NULL : module, 0, NULL, NULL, formatted);
 
     if (level <= current_log_level) {
         fprintf(stderr, "%10.3fs %s[%4s %-20s]\x1b[0m %s\n", (getticks_us() - start)/1000000.0, color_str, level_str, module, formatted);

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,57 @@
+#include "log.h"
+#include <stdint.h>
+#include <time.h>
+#include <PmLogLib.h>
+
+uint64_t start = 0;
+PmLogContext context;
+LogLevel current_log_level = Info;
+
+uint64_t getticks_us()
+{
+    struct timespec tp;
+    clock_gettime(CLOCK_MONOTONIC, &tp);
+    return tp.tv_sec * 1000000 + tp.tv_nsec / 1000;
+}
+
+void log_init() {
+    PmLogGetContext("hyperion-webos", &context);
+}
+
+void log_set_level(LogLevel level) {
+    current_log_level = level;
+}
+
+void log_printf(LogLevel level, const char* module, const char* fmt, ...) {
+    va_list args;
+    va_start (args, fmt);
+    const char* level_str;
+    const char* color_str;
+
+    if (start == 0)
+        start = getticks_us();
+
+    if (level == Debug) {
+        level_str = "DBG";
+        color_str = "\x1b[34m";
+    } else if (level == Info) {
+        level_str = "INFO";
+        color_str = "\x1b[36m";
+    } else if (level == Warning) {
+        level_str = "WARN";
+        color_str = "\x1b[33m";
+    } else {
+        level_str = "ERR";
+        color_str = "\x1b[31m";
+    }
+
+    char formatted[1024];
+    vsnprintf(formatted, 1024, fmt, args);
+    _PmLogMsgKV(context, level, 0, module, 0, NULL, NULL, formatted);
+
+    if (level <= current_log_level) {
+        fprintf(stderr, "%10.3fs %s[%4s %-20s]\x1b[0m %s\n", (getticks_us() - start)/1000000.0, color_str, level_str, module, formatted);
+    }
+
+    va_end (args);
+}

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <stdarg.h>
+#include <stdio.h>
+
+typedef enum {
+    Error = 3,
+    Warning = 4,
+    Info = 6,
+    Debug = 7,
+} LogLevel;
+
+void log_init();
+void log_set_level(LogLevel level);
+void log_printf(LogLevel level, const char* module, const char* fmt, ...);
+
+#define LOG(level, ...) log_printf(level, __FUNCTION__, __VA_ARGS__)
+#define ERR(...) LOG(Error, __VA_ARGS__)
+#define WARN(...) LOG(Warning, __VA_ARGS__)
+#define INFO(...) LOG(Info, __VA_ARGS__)
+#define DBG(...) LOG(Debug, __VA_ARGS__)

--- a/src/main.c
+++ b/src/main.c
@@ -13,13 +13,10 @@
 #include <sys/stat.h>
 #include <libgen.h>
 #include "common.h"
+#include "log.h"
 #include "hyperion_client.h"
-#include <glib.h>
-#include <glib-object.h>
-#include <lunaservice.h>
 #include <luna-service2/lunaservice.h>
 #include <pbnjson.h>
-#include <PmLogLib.h>
 
 #define SERVICE_NAME "org.webosbrew.piccap.service"
 #define BUF_SIZE 64
@@ -29,7 +26,7 @@
 
 #define DLSYM_ERROR_CHECK()                                         \
     if ((error = dlerror()) != NULL)  {                             \
-        fprintf(stderr, "Error! dlsym failed, msg: %s\n", error);   \
+        ERR("Error! dlsym failed, msg: %s", error);                 \
         return -2;                                                  \
     }
 
@@ -44,6 +41,7 @@ static struct option long_options[] = {
     {"no-service", no_argument, 0, 'S'},
     {"backend", required_argument, 0, 'b'},
     {"help", no_argument, 0, 'h'},
+    {"verbose", no_argument, 0, 'v'},
     {"config", required_argument, 0, 'c'},
     {"save-conf", required_argument, 0, 's'},
     {0, 0, 0, 0},
@@ -53,7 +51,6 @@ pthread_t connection_thread;
 
 // Main loop for aliving background service
 GMainLoop *gmainLoop;
-PmLogContext logcontext;
 
 LSHandle  *sh = NULL;
 LSMessage *message;
@@ -115,7 +112,7 @@ int save_settings(const char *savestring);
 int remove_settings();
 
 int luna_resp(LSHandle *sh, LSMessage *message, char *replyPayload, LSError *lserror);
-//JSON helper functions
+// JSON helper functions
 char* jval_to_string(jvalue_ref parsed, const char *item, const char *def);
 bool jval_to_bool(jvalue_ref parsed, const char *item, bool def);
 int jval_to_int(jvalue_ref parsed, const char *item, int def);
@@ -143,11 +140,9 @@ int get_starting_path(char *retstr){
      
     /* Catch some errors: */
     if (length < 0) {
-        PmLogError(logcontext, "FNCGPATH", 0, "Error resolving symlink /proc/self/exe.");
         return -1;
     }
     if (length >= FILENAME_MAX) {
-        PmLogError(logcontext, "FNCGPATH", 0, "Path too long. Truncated.");
         return -1;
     }
 
@@ -159,7 +154,7 @@ int get_starting_path(char *retstr){
     strcat(dirpath,"/");
 
     strcpy(retstr,dirpath);
-    PmLogInfo(logcontext, "FNCGPATH", 0, "Full path is: %s", retstr);
+    DBG("Full path is: %s", retstr);
     return 0;
 }
 
@@ -167,14 +162,13 @@ static int import_backend_library(const char *library_filename) {
     char *error;
     char libpath[FILENAME_MAX] = "\0";
 
-    PmLogInfo(logcontext, "FNCDLOPEN", 0, "Full exec path: %s", libpath);
     strcat(libpath, basepath);
     strcat(libpath, library_filename);
-    PmLogInfo(logcontext, "FNCDLOPEN", 0, "Full library path: %s", libpath);
+    DBG("Full library path: %s", libpath);
 
     void *handle = dlopen(libpath, RTLD_LAZY);
     if (handle == NULL) {
-        PmLogError(logcontext, "FNCDLOPEN", 0, "Error! Failed to load backend library: %s, error: %s", libpath, dlerror());
+        ERR("Failed to load backend library: %s, error: %s", libpath, dlerror());
         return -1;
     }
 
@@ -190,7 +184,7 @@ static int import_backend_library(const char *library_filename) {
 }
 
 int set_default(){
-    PmLogInfo(logcontext, "FNCSETDEF", 0, "Setting default settings to runtime..");
+    DBG("Setting default settings to runtime...");
     _address = "";
     _port = 19400;
     config.resolution_width = 360;
@@ -200,7 +194,7 @@ int set_default(){
     config.no_video = false;
     config.no_gui = false;
     autostart = false;
-    PmLogInfo(logcontext, "FNCSETDEF", 0, "Finished setting default.");
+    DBG("Finished setting default.");
     return 0;
 }
 
@@ -208,22 +202,21 @@ int check_root(LSHandle *handle){
     int uid;
     uid = geteuid();
     if(uid != 0){
-        PmLogError(logcontext, "FNCISROOT", 0, "Service is not running as root! ID: %d", uid);
+        WARN("Service is not running as root! ID: %d", uid);
         rooted = false;
-        PmLogInfo(logcontext, "FNCISROOT", 0, "Trying to evaluate using HBChannel/exec-Service!");
+        INFO("Trying to elevate using Homebrew Channel exec service...");
         if(make_root(handle) != 0){
-            PmLogError(logcontext, "FNCISROOT", 0, "Error while making root!");
+            ERR("Error while making root!");
         }
     }else{
-        PmLogInfo(logcontext, "FNCISROOT", 0, "Service is running as root!");
+        DBG("Service is running as root!");
         rooted = true;
     }
     return 0;
 }
 
 static bool cb_make_root(LSHandle *sh, LSMessage *msg, void *user_data){
-
-    PmLogInfo(logcontext, "FNCMKROOTCB", 0, "Callback received.");
+    DBG("Callback received.");
     JSchemaInfo schemaInfo;
     jvalue_ref parsed = {0}, value = {0};
 
@@ -236,27 +229,26 @@ static bool cb_make_root(LSHandle *sh, LSMessage *msg, void *user_data){
     LSErrorInit(&lserror);
 
 
-    PmLogInfo(logcontext, "FNCMKROOTCB", 0,  "Parsing values from msg input..");
+    DBG("Parsing values from msg input...");
     parsed = jdom_parse(j_cstr_to_buffer(LSMessageGetPayload(msg)), DOMOPT_NOOPT, &schemaInfo);
 
 	if (jis_null(parsed)) {
-        PmLogInfo(logcontext, "FNCMKROOTCB", 0,  "Failed parsing values from msg input!");
+        WARN("Failed parsing values from msg input!");
         j_release(&parsed);
         return false;
     }
 
-    PmLogInfo(logcontext, "FNCMKROOTCB", 0,  "Checking returnvalue..");
+    DBG("Checking returnvalue...");
 	retval = jval_to_bool(parsed, "returnValue", false); 
 
-    if(retval)
-    {
-        PmLogInfo(logcontext, "FNCMKROOTCB", 0,  "Returnvalue true, checking stdoutString..");
+    if (retval) {
+        DBG("Returnvalue true, checking stdoutString...");
         retstr = jval_to_string(parsed, "stdoutString", "No value!");
-        PmLogInfo(logcontext, "FNCMKROOTCB", 0, "HBChannel/exec returned: %s", retstr);
-        PmLogInfo(logcontext, "FNCMKROOTCB", 0, "Lets terminate us, to get restarted! :)");
+        DBG("HBChannel/exec returned: %s", retstr);
+        DBG("Lets terminate us, to get restarted! :)");
         raise(SIGTERM);
-    }else{
-        PmLogError(logcontext, "FNCMKROOTCB", 0, "Returnvalue false! Errors occoured.");
+    } else {
+        ERR("Returnvalue false! Errors occured: %s", LSMessageGetPayload(msg));
     }
 
     return true;
@@ -265,7 +257,7 @@ static bool cb_make_root(LSHandle *sh, LSMessage *msg, void *user_data){
 int make_root(LSHandle *handle){
     LSError lserror;
     if(!LSCall(handle, "luna://org.webosbrew.hbchannel.service/exec","{\"command\":\"/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/elevate-service org.webosbrew.piccap.service\"}", cb_make_root, NULL, NULL, &lserror)){
-        PmLogError(logcontext, "FNCMKROOT", 0, "Error while executing HBChannel/exec!");
+        ERR("Error while executing HBChannel/exec!");
         LSErrorPrint(&lserror, stderr);
         return 1;
     }
@@ -293,23 +285,23 @@ static void handle_signal(int signal)
     switch (signal)
     {
     case SIGINT:
-        PmLogError(logcontext, "SIGINT", 0, "SIGINT called! Stopping capture if running..");
+        INFO("SIGINT called! Stopping capture if running..");
         app_quit = true;
         break;
     case SIGTERM:
-        PmLogError(logcontext, "SIGTERM", 0, "SIGTERM called! Stopping capture if running and exit..");
+        INFO("SIGTERM called! Stopping capture if running and exit..");
         exitme = true;
         app_quit = true;
         exit(0);
         break;
     case SIGCONT:
-        PmLogError(logcontext, "SIGCONT", 0, "SIGCONT called! Stopping capture if running and rerun from scratch..");
+        INFO("SIGCONT called! Stopping capture if running and rerun from scratch..");
         app_quit = true;
         if ((capture_main()) != 0){
-            PmLogError(logcontext, "SIGCONT", 0,  "ERROR: Capture main init failed! Will quit..");
+            ERR("ERROR: Capture main init failed! Will quit..");
             break;
         }
-        PmLogInfo(logcontext, "SIGCONT", 0,  "Capture main started!");
+        DBG("Capture main started!");
         break;
     default:
         break;
@@ -339,13 +331,12 @@ static void print_usage()
 
 static int parse_options(int argc, char *argv[])
 {
-    PmLogInfo(logcontext, "FNCPARSEOPT", 0, "Starting parsing arguments..");
-    PmLogInfo(logcontext, "FNCPARSEOPT", 0, "Setting default settings before parsing..");
     if(set_default() != 0){
-        PmLogError(logcontext, "FNCPARSEOPT", 0, "Error while setting default settings!");
+        ERR("Error while setting default settings!");
     }
+
     int opt, longindex;
-    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:h:c:s:SVG", long_options, &longindex)) != -1)
+    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:h:c:s:vSVG", long_options, &longindex)) != -1)
     {
         switch (opt)
         {
@@ -373,6 +364,10 @@ static int parse_options(int argc, char *argv[])
         case 'S':
             config.no_service = 1;
             break;
+        case 'v':
+            config.verbose = 1;
+            log_set_level(Debug);
+            break;
         case 'b':
             _backend = strdup(optarg);
             break;
@@ -386,6 +381,7 @@ static int parse_options(int argc, char *argv[])
             break;
         case 'h':
         default:
+            WARN("Unknown option: %c", opt);
             print_usage();
             return 1;
         }
@@ -393,17 +389,17 @@ static int parse_options(int argc, char *argv[])
 
     if (config.no_service == 1){
         if (config.load_config == 1){
-            PmLogInfo(logcontext, "FNCPARSEOPT", 0, "Loading settings from disk to runtime..");
+            DBG("Loading settings from disk to runtime...");
             if(load_settings() != 0){
-                PmLogError(logcontext, "FNCPARSEOPT", 0, "Error while loading settings!");
+                ERR("Error while loading settings!");
             }
-            PmLogInfo(logcontext, "FNCPARSEOPT", 0, "Finished loading settings.");
+            DBG("Finished loading settings");
         }
 
         if (config.save_config == 1){
             jvalue_ref tosave = {0};
 
-            PmLogInfo(logcontext, "FNCPARSEOPT", 0, "Creating JSON-String to save..");
+            DBG("Creating JSON-String to save...");
             tosave = jobject_create();
             jobject_set(tosave, j_cstr_to_buffer("address"), jstring_create(_address));
             jobject_set(tosave, j_cstr_to_buffer("port"), jnumber_create_i32(_port));
@@ -414,26 +410,23 @@ static int parse_options(int argc, char *argv[])
             jobject_set(tosave, j_cstr_to_buffer("novideo"), jboolean_create(config.no_video));
             jobject_set(tosave, j_cstr_to_buffer("nogui"), jboolean_create(config.no_gui));
             jobject_set(tosave, j_cstr_to_buffer("autostart"), jboolean_create(autostart));
-            
-            PmLogInfo(logcontext, "FNCPARSEOPT", 0, "Saving JSON-String to disk..");
+
+            DBG("Saving JSON-String to disk...");
 
             if(save_settings(jvalue_tostring_simple(tosave)) != 0){
-                PmLogError(logcontext, "FNCPARSEOPT", 0, "Error while saveing settings to disk!");
+                ERR("Error while saving settings to disk!");
             }
             j_release(&tosave);
-            PmLogInfo(logcontext, "FNCPARSEOPT", 0, "Finished saving settings.");
         }
 
 
         if (strcmp(_address, "") == 0)
         {
-            PmLogError(logcontext, "FNCPARSEOPT", 0, "Error! Address not specified.\n");
             print_usage();
             return 1;
         }
         if (config.fps < 0 || config.fps > 60)
         {
-            PmLogError(logcontext, "FNCPARSEOPT", 0, "Error! FPS should between 0 (unlimited) and 60.\n");
             print_usage();
             return 1;
         }
@@ -442,20 +435,21 @@ static int parse_options(int argc, char *argv[])
         else
             config.framedelay_us = 1000000 / config.fps;
     }
-    PmLogInfo(logcontext, "FNCPARSEOPT", 0, "Finished parsing arguments.");
+
+    DBG("Finished parsing arguments");
     return 0;
 }
 
 
 int main(int argc, char *argv[])
 {
-    PmLogGetContext("hyperion-webos_service", &logcontext);
-    PmLogInfo(logcontext, "FNCMAIN", 0, "Service main starting..");
+    log_init();
+    INFO("Starting up...");
     signal(SIGINT, handle_signal);
     signal(SIGTERM, handle_signal);
     signal(SIGCONT, handle_signal);
 
-    PmLogInfo(logcontext, "FNCMAIN", 0, "Getting basepath..");
+    DBG("Getting basepath..");
     get_starting_path(basepath);
 
     int ret;
@@ -464,7 +458,7 @@ int main(int argc, char *argv[])
         return ret;
     }
 
-    if(config.no_service == 1){
+    if (config.no_service == 1) {
 
         if (getenv("XDG_RUNTIME_DIR") == NULL)
         {
@@ -472,17 +466,21 @@ int main(int argc, char *argv[])
         }
 
         if ((capture_main()) != 0){
-            PmLogError(logcontext, "FNCSTART", 0,  "ERROR: Capture main init failed!");
+            ERR("ERROR: Capture main init failed!");
             return 1;
         }
+
+        pthread_join(connection_thread, NULL);
+
+        INFO("Finished");
         return ret;
 
-    }else{
+    } else {
 
         LSError lserror;
         LSHandle  *handle = NULL;
         bool bRetVal = FALSE;
-        
+
         LSErrorInit(&lserror);
 
         // create a GMainLoop
@@ -499,35 +497,34 @@ int main(int argc, char *argv[])
 
         LSGmainAttach(handle, gmainLoop, &lserror);
 
-        PmLogInfo(logcontext, "FNCMAIN", 0, "Checking service root status..");
+        DBG("Checking service root status...");
         if(check_root(handle) != 0){
-            PmLogError(logcontext, "FNCMAIN", 0, "Error while checking for root status!");
+            ERR("Error while checking for root status!");
         }
 
-        PmLogInfo(logcontext, "FNCMAIN", 0, "Setting default settings before loading..");
+        DBG("Setting default settings before loading...");
         if(set_default() != 0){
-            PmLogError(logcontext, "FNCMAIN", 0, "Error while setting default settings!");
+            ERR("Error while setting default settings!");
         }
 
-        PmLogInfo(logcontext, "FNCMAIN", 0, "Loading settings from disk to runtime..");
+        DBG("Loading settings from disk to runtime...");
         if(load_settings() != 0){
-            PmLogError(logcontext, "FNCMAIN", 0, "Error while loading settings!");
+            ERR("Error while loading settings!");
         }
 
         if(autostart && !rooted){
-            PmLogError(logcontext, "FNCMAIN", 0, "Service isn't rooted! Setting autostart to false.");
+            WARN("Service isn't rooted! Setting autostart to false.");
             autostart = false;
         }
 
         if(autostart){
             if (isrunning){
-                PmLogError(logcontext, "FNCMAIN", 0,  "Capture already running");
+                WARN("autostart - Capture already running");
                 goto skip;
             }
 
             //Ensure set before starting
             if (strcmp(_address, "") == 0 || strcmp(_backend, "") == 0 || config.fps < 0 || config.fps > 60){
-                PmLogError(logcontext, "FNCMAIN", 0, "ERROR: Address and Backend are neccassary parameters and FPS should be between 0 (unlimited) and 60! | Address: %s | Backend: %s | FPS: %d", _address, _backend, config.fps);
                 goto skip;
             }
 
@@ -536,20 +533,16 @@ int main(int argc, char *argv[])
             }else{
                 config.framedelay_us = 1000000 / config.fps;
             }
-
-            PmLogInfo(logcontext, "FNCMAIN", 0, "Using these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
-            PmLogInfo(logcontext, "FNCMAIN", 0,  "Calling capture start main..");
-
             //luna-send -a org.webosbrew.piccap -f -n 1 luna://com.webos.notification/createToast '{"sourceId":"org.webosbrew.piccap","message": "PicCap startup is enabled! Calling service for startup.."}'
             if(!LSCall(handle, "luna://com.webos.notification/createToast","{\"sourceId\":\"org.webosbrew.piccap\",\"message\": \"PicCap startup is enabled! Calling service for startup..\"}", NULL, NULL, NULL, &lserror)){
-                PmLogError(logcontext, "FNCMAIN", 0, "Error while executing toast notification!");
+                ERR("Error while executing toast notification!");
                 LSErrorPrint(&lserror, stderr);
             }
 
             if ((capture_main()) != 0){
-                PmLogError(logcontext, "FNCMAIN", 0,  "ERROR: Capture main init failed!");
+                ERR("Capture main init failed!");
                 if(!LSCall(handle, "luna://com.webos.notification/createToast","{\"sourceId\":\"org.webosbrew.piccap\",\"message\": \"Error while executing PicCap-Startup!\"}", NULL, NULL, NULL, &lserror)){
-                    PmLogError(logcontext, "FNCMAIN", 0, "Error while executing toast notification!");
+                    ERR("Error while executing toast notification!");
                     LSErrorPrint(&lserror, stderr);
                 }
                 goto skip;
@@ -558,75 +551,93 @@ int main(int argc, char *argv[])
         }
 
         skip:
-            PmLogInfo(logcontext, "FNCMAIN", 0, "Going into main loop..");
+            DBG("Going into main loop..");
             // run to check continuously for new events from each of the event sources
             g_main_loop_run(gmainLoop);
             // Decreases the reference count on a GMainLoop object by one
             g_main_loop_unref(gmainLoop);
 
-            PmLogInfo(logcontext, "FNCMAIN", 0, "Service main finishing..");
+            DBG("Service main finishing..");
 
     }
     return 0;
 }
 
 int capture_main(){
+    int ret;
     initialized = false;
-    PmLogInfo(logcontext, "FNCCPTMAIN", 0, "Beginning capture main init..");
-    PmLogInfo(logcontext, "FNCCPTMAIN", 0, "Detecting backend..");
+
+    //Ensure set before starting
+    if (strcmp(_address, "") == 0 || strcmp(_backend, "") == 0 || config.fps < 0 || config.fps > 60){
+        ERR("ERROR: Address and Backend are neccassary parameters and FPS should be between 0 (unlimited) and 60! | Address: %s | Backend: %s | FPS: %d", _address, _backend, config.fps);
+        return -1;
+    }
+
+    if (config.fps == 0){
+        config.framedelay_us = 0;
+    }else{
+        config.framedelay_us = 1000000 / config.fps;
+    }
+
+    DBG("Using these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
+
+    DBG("Detecting backend...");
     if ((detect_backend()) != 0)
     {
-        PmLogError(logcontext, "FNCCPTMAIN", 0, "Error! detect_backend.");
+        ERR("Error! detect_backend.");
         cleanup();
         return -1;
     }
 
-    PmLogInfo(logcontext, "FNCCPTMAIN", 0, "Detecting backend..");
-    if ((backend.capture_preinit(&config, &image_data_cb)) != 0)
+    DBG("Backend preinit...");
+    if ((ret = backend.capture_preinit(&config, &image_data_cb)) != 0)
     {
-        PmLogError(logcontext, "FNCCPTMAIN", 0, "Error! capture_preinit.");
+        ERR("Error! capture_preinit: %d", ret);
         cleanup();
         return -1;
     }
 
-    PmLogInfo(logcontext, "FNCCPTMAIN", 0, "Initiating capture..");
-    if ((backend.capture_init()) != 0)
+    DBG("Initiating capture...");
+    if ((ret = backend.capture_init()) != 0)
     {
-        PmLogError(logcontext, "FNCCPTMAIN", 0, "Error! capture_init.");
+        ERR("Error! capture_init: %d", ret);
         cleanup();
         return -1;
     }
 
-    PmLogInfo(logcontext, "FNCCPTMAIN", 0, "Starting capture..");
-    int ret;
+    DBG("Starting capture..");
     if ((ret = backend.capture_start()) != 0)
     {
-        PmLogError(logcontext, "FNCCPTMAIN", 0, "Error! capture_start. Code: %d", ret);
+        ERR("Error! capture_start. Code: %d", ret);
         cleanup();
         return -1;
     }
 
-    PmLogInfo(logcontext, "FNCCPTMAIN", 0, "Capture main init completed. Creating subproccess for looping..");
+    DBG("Capture main init completed. Creating connection thread...");
+
     initialized = true;
     app_quit = false;
     isrunning = true;
+
     if (pthread_create(&connection_thread, NULL, connection_loop, NULL) != 0) {
         return -1;
     }
+
     return 0;
 }
 
 void *connection_loop(void *data){
-    PmLogInfo(logcontext, "FNCCPTLOOP", 0, "Starting connection loop");
+    DBG("Starting connection loop");
     while (!app_quit)
     {
-        PmLogInfo(logcontext, "FNCCPTMAIN", 0, "Connecting hyperion-client..");
+        INFO("Connecting hyperion-client..");
         if ((hyperion_client("webos", _address, _port, 150)) != 0) {
-            PmLogError(logcontext, "FNCCPTMAIN", 0, "Error! hyperion_client.");
+            ERR("Error! hyperion_client.");
         } else {
+            INFO("hyperion-client connected!");
             while (!app_quit) {
                 if (hyperion_read() < 0) {
-                    PmLogError(logcontext, "FNCCPTLOOP", 0, "Error! Connection timeout.");
+                    ERR("Error! Connection timeout.");
                     break;
                 }
             }
@@ -635,42 +646,46 @@ void *connection_loop(void *data){
         hyperion_destroy();
 
         if (!app_quit) {
-            PmLogInfo(logcontext, "FNCCPTMAIN", 0, "Connection destroyed, waiting...");
+            INFO("Connection destroyed, waiting...");
             sleep(1);
         }
     }
 
-    PmLogInfo(logcontext, "FNCCPTLOOP", 0, "Ending connection loop");
+    INFO("Ending connection loop");
     if(exitme){
-        PmLogInfo(logcontext, "FNCCPTLOOP", 0, "exitme true -> Exit");
+        INFO("exitme true -> Exit");
         exit(0);
     }
+
+    isrunning = false;
     cleanup();
+
+    DBG("Connection loop exiting");
     return 0;
 }
 
 int cleanup(){
-    PmLogInfo(logcontext, "FNCCLEAN", 0, "Starting cleanup..");
+    DBG("Starting cleanup...");
     if (isrunning){
-        PmLogInfo(logcontext, "FNCCLEAN", 0, "Capture is running! Breaking loop and joining thread..");
+        DBG("Capture is running! Breaking loop and joining thread...");
         app_quit=true;
         pthread_join(connection_thread, NULL);
         isrunning=false;
     }
-    PmLogInfo(logcontext, "FNCCLEAN", 0, "Destroying hyperion-client..");
+    DBG("Destroying hyperion-client...");
     hyperion_destroy();
     if(initialized){
         if (backend.capture_terminate) {
-            PmLogInfo(logcontext, "FNCCLEAN", 0, "Terminating capture within library..");
+            DBG("Terminating capture within library...");
             backend.capture_terminate();
             initialized = false;
         }
     }
     if (backend.capture_cleanup) {
-        PmLogInfo(logcontext, "FNCCLEAN", 0, "Cleanup capture within library..");
+        DBG("Cleanup capture within library...");
         backend.capture_cleanup();
     }
-    PmLogInfo(logcontext, "FNCCLEAN", 0, "Cleanup finished.");
+    DBG("Cleanup finished.");
     return 0;
 }
 
@@ -678,7 +693,7 @@ static int image_data_cb(int width, int height, uint8_t *rgb_data)
 {
     if (hyperion_set_image(rgb_data, width, height) != 0)
     {
-        PmLogError(logcontext, "FNCIMGDATA", 0, "Error! Write timeout.");
+        ERR("Error! Write timeout.");
     }
 }
 
@@ -692,7 +707,7 @@ int load_settings(){
 
     
 
-    PmLogInfo(logcontext, "FNCLOADCFG", 0,  "Try to read configfile.");
+    DBG("Try to read configfile.");
     if(strcmp(_configpath, "") == 0){
         strcat(confpath, basepath);
         strcat(confpath, conffile);
@@ -709,30 +724,30 @@ int load_settings(){
         confbuf[sstr] = '\0';
         retvalue = 0;
         if(sstr != sconf){
-            PmLogError(logcontext, "FNCLOADCFG", 0,  "Errors reading configfile at location %s", confpath);
+            ERR("Errors reading configfile at location %s", confpath);
             free(confbuf);
             fclose(jconf);
             return 2;
         }
         fclose(jconf);
     }else{
-        PmLogError(logcontext, "FNCLOADCFG", 0,  "Couldn't read configfile at location %s", confpath);
+        ERR("Couldn't read configfile at location %s", confpath);
         retvalue = 1;
     }
 
-    if(retvalue == 0){
-        PmLogInfo(logcontext, "FNCLOADCFG", 0,  "Read configfile at %s. Contents: %s", confpath, confbuf);
+    if (retvalue == 0) {
+        DBG("Read configfile at %s. Contents: %s", confpath, confbuf);
         jschema_info_init (&schemaInfo, jschema_all(), NULL, NULL);
         parsed = jdom_parse(j_cstr_to_buffer(confbuf), DOMOPT_NOOPT, &schemaInfo);
         if (jis_null(parsed)) {
-            PmLogError(logcontext, "FNCLOADCFG", 0,  "Error parsing config.");
+            ERR("Error parsing config.");
             j_release(&parsed);
             free(confbuf);
             return 2;
         }
         free(confbuf);
-    }else{
-        PmLogError(logcontext, "FNCLOADCFG", 0,  "config.json at path %s may not found! Will be using default configuration.", confpath);
+    } else {
+        WARN("config.json at path %s may not found! Will be using default configuration.", confpath);
     }
 
 
@@ -746,14 +761,14 @@ int load_settings(){
     config.no_gui = jval_to_bool(parsed, "nogui", config.no_gui);
     autostart = jval_to_bool(parsed, "autostart", autostart);
 
-    PmLogInfo(logcontext, "FNCLOADCFG", 0, "Loaded these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
+    DBG("Loaded these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
     j_release(&parsed);
     return retvalue;
 }
 
 bool method_get_settings(LSHandle *sh, LSMessage *message, void *data)
 {
-    PmLogInfo(logcontext, "FNCGCONF", 0,  "Luna call getSettings recieved.");
+    DBG("Luna call getSettings recieved.");
     LSError lserror;
     JSchemaInfo schemaInfo;
     jvalue_ref value = {0};
@@ -764,22 +779,20 @@ bool method_get_settings(LSHandle *sh, LSMessage *message, void *data)
 
     LSErrorInit(&lserror);
 
-    // Initialize schema
-   
     load = load_settings();
     if(load == 0){
-        PmLogInfo(logcontext, "FNCGCONF", 0, "Loading settings successfully.");
-    }else if(load == 1){
-        PmLogInfo(logcontext, "FNCGCONF", 0, "Loading settings not successfully. Using default settings.");
-    }else{ 
-        PmLogInfo(logcontext, "FNCGCONF", 0, "Error while loading settings. Sending back error.");
+        DBG("Loading settings successfully.");
+    } else if(load == 1) {
+        WARN("Loading settings not successfully. Using default settings.");
+    } else {
+        WARN("Error while loading settings. Sending back error.");
         backmsg = "Error loading settings!";
         luna_resp(sh, message, backmsg, &lserror);
         return true;
     }
 
-    PmLogInfo(logcontext, "FNCGCONF", 0, "Sending these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
- 
+    DBG("Sending these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
+
     //Response
     jobj = jobject_create();
     jreturnValue = jboolean_create(TRUE);
@@ -798,7 +811,7 @@ bool method_get_settings(LSHandle *sh, LSMessage *message, void *data)
 
     LSMessageReply(sh, message, jvalue_tostring_simple(jobj), &lserror);
 
-    PmLogInfo(logcontext, "FNCGCONF", 0,  "Luna call getSettings finished.");
+    DBG("Luna call getSettings finished.");
     j_release(&jobj);
     return true;
 }
@@ -807,7 +820,7 @@ int save_settings(const char *savestring){
     char confpath[FILENAME_MAX] = "\0";
     int retvalue = 0;
 
-    PmLogInfo(logcontext, "FNCSAVECFG", 0,  "Try to save configfile.");
+    DBG("Try to save configfile.");
     if(strcmp(_configpath, "") == 0){
         strcat(confpath, basepath);
         strcat(confpath, conffile);
@@ -815,19 +828,19 @@ int save_settings(const char *savestring){
         strcat(confpath, _configpath);
     }
     FILE *jconf = fopen(confpath,"w+");
-    if(jconf){
-        PmLogInfo(logcontext, "FNCSAVECFG", 0,  "File opened, writing JSON..");
+    if(jconf) {
+        DBG("File opened, writing JSON..");
         fwrite(savestring, 1, strlen(savestring), jconf);
         fclose(jconf);
         retvalue = 0;
-    }else{
-        PmLogInfo(logcontext, "FNCSAVECFG", 0,  "Couldn't open configfile for write at location %s", confpath);
+    } else {
+        WARN("Couldn't open configfile for write at location %s", confpath);
         retvalue = 1;
     }
 
-    PmLogInfo(logcontext, "FNCSAVECFG", 0,  "Autostart: %d", autostart);
+    DBG("Autostart: %d", autostart);
     if (autostart){
-        PmLogInfo(logcontext, "FNCSAVECFG", 0,  "Autostart enabled. Checking symlink.");
+        DBG("Autostart enabled. Checking symlink.");
         char *startpath = "/var/lib/webosbrew/init.d/piccapautostart";
         char *startupdir = "/var/lib/webosbrew/init.d";
         char origpath[FILENAME_MAX];
@@ -837,15 +850,15 @@ int save_settings(const char *savestring){
         strcat(origpath, autostartfile);
 
         if(access(startpath, F_OK) == 0){
-            PmLogInfo(logcontext, "FNCSAVECFG", 0,  "Autostart enabled. Symlink to HBChannel init.d already exists. Nothing to do");
+            DBG("Autostart enabled. Symlink to HBChannel init.d already exists. Nothing to do");
         }else{
-            PmLogInfo(logcontext, "FNCSAVECFG", 0,  "Autostart enabled. Trying to create symlink to HBChannel init.d.");
+            INFO("Autostart enabled. Trying to create symlink to HBChannel init.d.");
             mkdir(startupdir, 0755);
             if(symlink(origpath, startpath) != 0){
-                PmLogError(logcontext, "FNCSAVECFG", 0, "Error while creating symlink!");
+                ERR("Error while creating symlink!");
                 retvalue = 2;
             }else{
-                PmLogInfo(logcontext, "FNCSAVECFG", 0,  "Symlink created.");
+                INFO("Symlink created.");
             }
         }
     }
@@ -855,7 +868,7 @@ int save_settings(const char *savestring){
 
 bool method_set_settings(LSHandle *sh, LSMessage *message, void *data)
 {
-    PmLogInfo(logcontext, "FNCSCONF", 0,  "Luna call setSettings recieved.");
+    DBG("Luna call setSettings recieved.");
     LSError lserror;
     JSchemaInfo schemaInfo;
     jvalue_ref parsed = {0}, value = {0};
@@ -870,17 +883,18 @@ bool method_set_settings(LSHandle *sh, LSMessage *message, void *data)
     jschema_info_init (&schemaInfo, jschema_all(), NULL, NULL);
 
     // get message from LS2 and parsing to make object
-    PmLogInfo(logcontext, "FNCSCONF", 0,  "Parsing values from msg input..");
+    DBG("Parsing values from msg input..");
     parsed = jdom_parse(j_cstr_to_buffer(LSMessageGetPayload(message)), DOMOPT_NOOPT, &schemaInfo);
 
     if (jis_null(parsed)) {
+        ERR("Error while parsing input");
         j_release(&parsed);
         backmsg = "Error while parsing input!"; 
         luna_resp(sh, message, backmsg, &lserror);
         return true;
     }
 
-    PmLogInfo(logcontext, "FNCSCONF", 0,  "Putting parsed values to runtime..");
+    DBG("Putting parsed values to runtime..");
     _address = jval_to_string(parsed, "ip", _address);
     _port = jval_to_int(parsed, "port", _port);
     config.resolution_width = jval_to_int(parsed, "width", config.resolution_width);
@@ -892,7 +906,7 @@ bool method_set_settings(LSHandle *sh, LSMessage *message, void *data)
     autostart = jval_to_bool(parsed, "autostart", autostart);
 
 
-    PmLogInfo(logcontext, "FNCSCONF", 0,  "Creating JSON from runtime..");
+    DBG("Creating JSON from runtime..");
     tosave = jobject_create();
     jobject_set(tosave, j_cstr_to_buffer("address"), jstring_create(_address));
     jobject_set(tosave, j_cstr_to_buffer("port"), jnumber_create_i32(_port));
@@ -904,9 +918,9 @@ bool method_set_settings(LSHandle *sh, LSMessage *message, void *data)
     jobject_set(tosave, j_cstr_to_buffer("nogui"), jboolean_create(config.no_gui));
     jobject_set(tosave, j_cstr_to_buffer("autostart"), jboolean_create(autostart));
 
-    PmLogInfo(logcontext, "FNCSCONF", 0,  "Saving JSON to disk..");
+    DBG("Saving JSON to disk..");
     save = save_settings(jvalue_tostring_simple(tosave));
-    if(save != 0){
+    if (save != 0) {
         backmsg = "Errors while saving file to disk!";
         luna_resp(sh, message, backmsg, &lserror);
         j_release(&tosave);
@@ -914,7 +928,7 @@ bool method_set_settings(LSHandle *sh, LSMessage *message, void *data)
         return true;
     }
 
-    PmLogInfo(logcontext, "FNCSCONF", 0, "Saved these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
+    DBG("Saved these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
  
     //Response
     jobj = jobject_create();
@@ -925,7 +939,7 @@ bool method_set_settings(LSHandle *sh, LSMessage *message, void *data)
 
     LSMessageReply(sh, message, jvalue_tostring_simple(jobj), &lserror);
 
-    PmLogInfo(logcontext, "FNCSCONF", 0,  "Luna call setSettings finished.");
+    DBG("Luna call setSettings finished.");
     j_release(&jobj);
     j_release(&tosave);
     j_release(&parsed);
@@ -936,30 +950,30 @@ int remove_settings(){
     char confpath[FILENAME_MAX];
     int retval = 0;
 
-    PmLogInfo(logcontext, "FNCREMCFG", 0,  "Try to delete configfile.");
+    DBG("Try to delete configfile.");
     strcat(confpath, basepath);
     strcat(confpath, conffile);
     if(remove(confpath) != 0){
-        PmLogError(logcontext, "FNCREMCFG", 0,  "Error while deleting configfile at path %s", confpath);
+        ERR("Error while deleting configfile at path %s", confpath);
         retval = 1;
     }else{
-        PmLogInfo(logcontext, "FNCREMCFG", 0,  "Configfile successfully deleted at path %s", confpath);
+        DBG("Configfile successfully deleted at path %s", confpath);
         retval = 0;
     }
 
 
-    PmLogInfo(logcontext, "FNCREMCFG", 0,  "Removing autostart symlink, if exists.");
+    DBG("Removing autostart symlink, if exists.");
     char *startpath = "/var/lib/webosbrew/init.d/piccapautostart";
 
     if(access(startpath, F_OK) != 0){
-        PmLogInfo(logcontext, "FNCREMCFG", 0,  "Symlink doesnt exists. Nothing to do");
+        DBG("Symlink doesnt exists. Nothing to do");
     }else{
-        PmLogInfo(logcontext, "FNCREMCFG", 0,  "Autostart enabled. Trying to remove symlink to HBChannel init.d.");
+        DBG("Autostart enabled. Trying to remove symlink to HBChannel init.d.");
         if(unlink(startpath) != 0){
-            PmLogError(logcontext, "FNCREMCFG", 0, "Error while deleting symlink!");
+            ERR("Error while deleting symlink!");
             retval = 2;
         }else{
-            PmLogInfo(logcontext, "FNCREMCFG", 0,  "Symlink removed.");
+            DBG("Symlink removed.");
         }
     }
     
@@ -968,7 +982,7 @@ int remove_settings(){
 
 bool method_reset_settings(LSHandle *sh, LSMessage *message, void *data)
 {
-    PmLogInfo(logcontext, "FNCRCONF", 0,  "Luna call resetSettings recieved.");
+    DBG("Luna call resetSettings recieved.");
     LSError lserror;
     JSchemaInfo schemaInfo;
     jvalue_ref parsed = {0}, value = {0};
@@ -978,17 +992,17 @@ bool method_reset_settings(LSHandle *sh, LSMessage *message, void *data)
 
     LSErrorInit(&lserror);
 
-    PmLogInfo(logcontext, "FNCRCONF", 0,  "Removing settings..");
+    DBG("Removing settings..");
     if(remove_settings() != 0){
-        PmLogError(logcontext, "FNCRCONF", 0,  "Errors while removing settings.");
+        ERR("Errors while removing settings.");
         backmsg = "Errors while removing settings.";
         luna_resp(sh, message, backmsg, &lserror);
         return true;
     }
 
-    PmLogInfo(logcontext, "FNCRCONF", 0,  "Setting defaults..");
+    DBG("Setting defaults..");
     if(set_default() != 0){
-        PmLogError(logcontext, "FNCRCONF", 0,  "Errors while setting default settings!");
+        ERR("Errors while setting default settings!");
         backmsg = "Errors while setting default settings!";
         luna_resp(sh, message, backmsg, &lserror);
         return true;
@@ -996,7 +1010,7 @@ bool method_reset_settings(LSHandle *sh, LSMessage *message, void *data)
 
     //TODO: Maybe some other cleanup?
 
-    PmLogInfo(logcontext, "FNCRCONF", 0, "Set to these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
+    DBG("Set to these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
  
 
     //Response
@@ -1008,7 +1022,7 @@ bool method_reset_settings(LSHandle *sh, LSMessage *message, void *data)
 
     LSMessageReply(sh, message, jvalue_tostring_simple(jobj), &lserror);
 
-    PmLogInfo(logcontext, "FNCRCONF", 0,  "Luna call resetSettings finished.");
+    DBG("Luna call resetSettings finished.");
     j_release(&parsed);
     j_release(&jobj);
     return true;
@@ -1017,7 +1031,7 @@ bool method_reset_settings(LSHandle *sh, LSMessage *message, void *data)
 
 bool method_start(LSHandle *sh, LSMessage *message, void *data)
 {
-    PmLogInfo(logcontext, "FNCSTART", 0,  "Luna call start recieved.");
+    DBG("Luna call start recieved.");
     LSError lserror;
     JSchemaInfo schemaInfo;
     jvalue_ref parsed = {0}, value = {0};
@@ -1031,26 +1045,26 @@ bool method_start(LSHandle *sh, LSMessage *message, void *data)
     jschema_info_init (&schemaInfo, jschema_all(), NULL, NULL);
 
     // get message from LS2 and parsing to make object
-    PmLogInfo(logcontext, "FNCSTART", 0,  "Parsing values from msg input, ignored for now..");
+    DBG("Parsing values from msg input, ignored for now..");
     parsed = jdom_parse(j_cstr_to_buffer(LSMessageGetPayload(message)), DOMOPT_NOOPT, &schemaInfo);
 
     if (jis_null(parsed)) {
         j_release(&parsed);
-        PmLogError(logcontext, "FNCSTART", 0,  "Error while parsing input");
+        ERR("Error while parsing input");
         backmsg = "Error while parsing input!"; 
         luna_resp(sh, message, backmsg, &lserror);
         return true;
     }
 
     if (isrunning){
-        PmLogError(logcontext, "FNCSTART", 0,  "Capture already running");
+        ERR("Capture already running");
         backmsg = "Capture already running!";
         luna_resp(sh, message, backmsg, &lserror);
         return true;
     }
 
     if (!rooted){
-        PmLogError(logcontext, "FNCSTART", 0,  "Service not rooted");
+        ERR("Service not rooted");
         backmsg = "Service not running as root!";
         luna_resp(sh, message, backmsg, &lserror);
         return true;
@@ -1058,7 +1072,6 @@ bool method_start(LSHandle *sh, LSMessage *message, void *data)
 
     //Ensure set before starting
     if (strcmp(_address, "") == 0 || strcmp(_backend, "") == 0 || config.fps < 0 || config.fps > 60){
-        PmLogError(logcontext, "FNCSTART", 0, "ERROR: Address and Backend are neccassary parameters and FPS should be between 0 (unlimited) and 60! | Address: %s | Backend: %s | FPS: %d", _address, _backend, config.fps);
         backmsg = "ERROR: Address and Backend are neccassary parameters and FPS should be between 0 (unlimited) and 60!";
         luna_resp(sh, message, backmsg, &lserror);
         return true;
@@ -1069,12 +1082,10 @@ bool method_start(LSHandle *sh, LSMessage *message, void *data)
     }else{
         config.framedelay_us = 1000000 / config.fps;
     }
-
-    PmLogInfo(logcontext, "FNCSTART", 0, "Using these values: Address: %s | Port: %d | Width: %d | Height: %d | FPS: %d | Backend: %s | NoVideo: %d | NoGUI: %d | Autostart: %d", _address, _port, config.resolution_width, config.resolution_height, config.fps, _backend, config.no_video, config.no_gui, autostart);
-    PmLogInfo(logcontext, "FNCSTART", 0,  "Calling capture start main..");
+    DBG("Calling capture start main..");
 
     if ((capture_main()) != 0){
-        PmLogError(logcontext, "FNCSTART", 0,  "ERROR: Capture main init failed!");
+        ERR("ERROR: Capture main init failed!");
         backmsg = "ERROR: Capture main init failed!";
         luna_resp(sh, message, backmsg, &lserror);
         return true;
@@ -1098,7 +1109,7 @@ bool method_start(LSHandle *sh, LSMessage *message, void *data)
 
     LSMessageReply(sh, message, jvalue_tostring_simple(jobj), &lserror);
 
-    PmLogInfo(logcontext, "FNCSTART", 0,  "Luna call start finished.");
+    DBG("Luna call start finished.");
     j_release(&parsed);
     j_release(&jobj);
     return true;
@@ -1106,7 +1117,7 @@ bool method_start(LSHandle *sh, LSMessage *message, void *data)
 
 bool method_stop(LSHandle *sh, LSMessage *message, void *data)
 {
-    PmLogInfo(logcontext, "FNCSTOP", 0,  "Luna call stop recieved.");
+    DBG("Luna call stop recieved.");
     LSError lserror;
     JSchemaInfo schemaInfo;
     jvalue_ref parsed = {0}, value = {0};
@@ -1145,7 +1156,7 @@ bool method_stop(LSHandle *sh, LSMessage *message, void *data)
     jobject_set(jobj, j_cstr_to_buffer("backmsg"), jstring_create(backmsg));
     LSMessageReply(sh, message, jvalue_tostring_simple(jobj), &lserror);
 
-    PmLogInfo(logcontext, "FNCSTOP", 0,  "Luna call stop finished.");
+    DBG("Luna call stop finished.");
     j_release(&parsed);
     j_release(&jobj);
     return true;
@@ -1153,7 +1164,7 @@ bool method_stop(LSHandle *sh, LSMessage *message, void *data)
 
 bool method_restart(LSHandle *sh, LSMessage *message, void *data)
 {
-    PmLogInfo(logcontext, "FNCRESTART", 0,  "Luna call restart recieved.");
+    DBG("Luna call restart recieved.");
     LSError lserror;
     jvalue_ref jobj = {0}, jreturnValue = {0};
     char *backmsg = "No message";
@@ -1170,7 +1181,7 @@ bool method_restart(LSHandle *sh, LSMessage *message, void *data)
     LSMessageReply(sh, message, jvalue_tostring_simple(jobj), &lserror);
 
     j_release(&jobj);
-    PmLogInfo(logcontext, "FNCISRUN", 0,  "Luna call isRunning finished.");
+    DBG("Luna call isRunning finished.");
     raise(SIGTERM);
     return true;
 }
@@ -1178,7 +1189,7 @@ bool method_restart(LSHandle *sh, LSMessage *message, void *data)
 
 bool method_is_running(LSHandle *sh, LSMessage *message, void *data)
 {
-    PmLogInfo(logcontext, "FNCISRUN", 0,  "Luna call isRunning recieved.");
+    DBG("Luna call isRunning recieved.");
     LSError lserror;
     jvalue_ref jobj = {0}, jreturnValue = {0};
     char *backmsg = "No message";
@@ -1194,13 +1205,13 @@ bool method_is_running(LSHandle *sh, LSMessage *message, void *data)
     LSMessageReply(sh, message, jvalue_tostring_simple(jobj), &lserror);
 
     j_release(&jobj);
-    PmLogInfo(logcontext, "FNCISRUN", 0,  "Luna call isRunning finished.");
+    DBG("Luna call isRunning finished.");
     return true;
 }
 
 bool method_is_root(LSHandle *sh, LSMessage *message, void *data)
 {
-    PmLogInfo(logcontext, "FNCISROOT", 0,  "Luna call isRoot recieved.");
+    DBG("Luna call isRoot recieved.");
     LSError lserror;
     jvalue_ref jobj = {0}, jreturnValue = {0};
     char *backmsg = "No message";
@@ -1222,7 +1233,7 @@ bool method_is_root(LSHandle *sh, LSMessage *message, void *data)
     LSMessageReply(sh, message, jvalue_tostring_simple(jobj), &lserror);
 
     j_release(&jobj);
-    PmLogInfo(logcontext, "FNCISROOT", 0,  "Luna call isRoot finished.");
+    DBG("Luna call isRoot finished.");
     return true;
 }
 
@@ -1232,7 +1243,7 @@ char* jval_to_string(jvalue_ref parsed, const char *item, const char *def)
 	raw_buffer jbuf;
 
 	if (!jobject_get_exists(parsed, j_str_to_buffer(item, strlen(item)), &jobj) || !jis_string(jobj)) {
-        PmLogInfo(logcontext, "FNCJTOSTRN", 0,  "Didn't got a value for item: %s. Using default value: %s", item, def);
+        DBG("Didn't got a value for item: %s. Using default value: %s", item, def);
 		return g_strdup(def);
     }
 
@@ -1246,7 +1257,7 @@ bool jval_to_bool(jvalue_ref parsed, const char *item, bool def)
 	bool ret;
 
 	if (!jobject_get_exists(parsed, j_str_to_buffer(item, strlen(item)), &jobj) || !jis_boolean(jobj)) {
-        PmLogInfo(logcontext, "FNCJTOBOOL", 0,  "Didn't got a value for item: %s. Using default value: %d", item, def);
+        DBG("Didn't got a value for item: %s. Using default value: %d", item, def);
 		return def;
     }
 
@@ -1260,7 +1271,7 @@ int jval_to_int(jvalue_ref parsed, const char *item, int def)
 	int ret = 0;
 
 	if (!jobject_get_exists(parsed, j_str_to_buffer(item, strlen(item)), &jobj) || !jis_number(jobj)) {
-        PmLogInfo(logcontext, "FNCJTOINT", 0,  "Didn't got a value for item: %s. Using default value: %d", item, def);
+        DBG("Didn't got a value for item: %s. Using default value: %d", item, def);
 		return def;
     }
 	jnumber_get_i32(jobj, &ret);
@@ -1268,7 +1279,7 @@ int jval_to_int(jvalue_ref parsed, const char *item, int def)
 }
 
 int luna_resp(LSHandle *sh, LSMessage *message, char *replyPayload, LSError *lserror){  
-        PmLogInfo(logcontext, "FNCLRESP", 0,  "Responding with text: %s", replyPayload);
+        DBG("Responding with text: %s", replyPayload);
         jvalue_ref respobj = {0};
         respobj = jobject_create();
         jobject_set(respobj, j_cstr_to_buffer("returnValue"), jboolean_create(TRUE));

--- a/src/main.c
+++ b/src/main.c
@@ -273,6 +273,7 @@ static void handle_signal(int signal)
     case SIGINT:
         INFO("SIGINT called! Stopping capture if running..");
         app_quit = true;
+        g_main_loop_quit(gmainLoop);
         break;
     case SIGTERM:
         INFO("SIGTERM called! Stopping capture if running and exit..");
@@ -460,8 +461,9 @@ int main(int argc, char *argv[])
 
         bRetVal = LSRegister(SERVICE_NAME, &handle, &lserror);
         if (FALSE== bRetVal) {
+            ERR("Unable to register on Luna bus: %s", lserror.message);
             LSErrorFree( &lserror );
-            return 0;
+            return -1;
         }
         sh = LSMessageGetConnection(message);
 

--- a/src/main.c
+++ b/src/main.c
@@ -403,23 +403,9 @@ static int parse_options(int argc, char *argv[])
                 ERR("Error while saving settings to disk!");
             }
             j_release(&tosave);
-        }
 
-
-        if (strcmp(_address, "") == 0)
-        {
-            print_usage();
-            return 1;
+            DBG("Finished saving settings.");
         }
-        if (config.fps < 0 || config.fps > 60)
-        {
-            print_usage();
-            return 1;
-        }
-        if (config.fps == 0)
-            config.framedelay_us = 0;
-        else
-            config.framedelay_us = 1000000 / config.fps;
     }
 
     DBG("Finished parsing arguments");
@@ -509,16 +495,6 @@ int main(int argc, char *argv[])
                 goto skip;
             }
 
-            //Ensure set before starting
-            if (strcmp(_address, "") == 0 || strcmp(_backend, "") == 0 || config.fps < 0 || config.fps > 60){
-                goto skip;
-            }
-
-            if (config.fps == 0){
-                config.framedelay_us = 0;
-            }else{
-                config.framedelay_us = 1000000 / config.fps;
-            }
             //luna-send -a org.webosbrew.piccap -f -n 1 luna://com.webos.notification/createToast '{"sourceId":"org.webosbrew.piccap","message": "PicCap startup is enabled! Calling service for startup.."}'
             if(!LSCall(handle, "luna://com.webos.notification/createToast","{\"sourceId\":\"org.webosbrew.piccap\",\"message\": \"PicCap startup is enabled! Calling service for startup..\"}", NULL, NULL, NULL, &lserror)){
                 ERR("Error while executing toast notification!");
@@ -1056,18 +1032,6 @@ bool method_start(LSHandle *sh, LSMessage *message, void *data)
         return true;
     }
 
-    //Ensure set before starting
-    if (strcmp(_address, "") == 0 || strcmp(_backend, "") == 0 || config.fps < 0 || config.fps > 60){
-        backmsg = "ERROR: Address and Backend are neccassary parameters and FPS should be between 0 (unlimited) and 60!";
-        luna_resp(sh, message, backmsg, &lserror);
-        return true;
-    }
-
-    if (config.fps == 0){
-        config.framedelay_us = 0;
-    }else{
-        config.framedelay_us = 1000000 / config.fps;
-    }
     DBG("Calling capture start main..");
 
     if ((capture_main()) != 0){

--- a/src/main.c
+++ b/src/main.c
@@ -117,39 +117,25 @@ char* jval_to_string(jvalue_ref parsed, const char *item, const char *def);
 bool jval_to_bool(jvalue_ref parsed, const char *item, bool def);
 int jval_to_int(jvalue_ref parsed, const char *item, int def);
 
+/**
+ * Returns base directory current executable is stored in
+ */
 int get_starting_path(char *retstr){
     int length;
     char fullpath[FILENAME_MAX];
     char *dirpath;
-     
-     /* /proc/self is a symbolic link to the process-ID subdir
-      * of /proc, e.g. /proc/4323 when the pid of the process
-      * of this program is 4323.
-      *
-      * Inside /proc/<pid> there is a symbolic link to the
-      * executable that is running as this <pid>.  This symbolic
-      * link is called "exe".
-      *
-      * So if we read the path where the symlink /proc/self/exe
-      * points to we have the full path of the executable.
-      * https://www.linuxquestions.org/questions/programming-9/get-full-path-of-a-command-in-c-117965/
-      */
 
+    length = readlink("/proc/self/exe", fullpath, sizeof(fullpath)-1);
 
-    length = readlink("/proc/self/exe", fullpath, sizeof(fullpath));
-     
     /* Catch some errors: */
     if (length < 0) {
-        return -1;
-    }
-    if (length >= FILENAME_MAX) {
+        ERR("Error resolving symlink /proc/self/exe.");
         return -1;
     }
 
-    /* I don't know why, but the string this readlink() function 
-    * returns is appended with a '@'.
-    */
-    fullpath[length] = '\0';       /* Strip '@' off the end. */
+    // readlink does not return null-limited string
+    fullpath[length] = '\0';
+
     dirpath = dirname(fullpath);
     strcat(dirpath,"/");
 


### PR DESCRIPTION
This adds unified logging library `src/lib.c` which routes messages to both colored `stderr` and PmLogLib. Log messages can contain calling function name, since all log calls are handled in a macro (function name is logged only to stderr now)

`--verbose` CLI option changes default `Info` logging level to `Debug`. Most `Info` messages from `main.c` were reworked to `Debug`. Tested main flow via service + cli with libdile_vt backend - libvt/libvtcapture have been reworked via a regex, but not tested. Built, so should likely work properly.

Additionally adds some minor reworks in separate commits:
* clarify why `readlink` ended with `@` (it's a non-null-terminated string)
* moved duplicated config validation into `capture_main`