### PR TITLE
use libyuv's functions for YUV/RGB stuff in libvtcapture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ add_library(vtcapture_backend SHARED
 
 target_compile_definitions(vtcapture_backend PRIVATE CAPTURE_BACKEND)
 target_include_directories(vtcapture_backend PRIVATE src src/backends)
-target_link_libraries(vtcapture_backend vtcapture halgal)
+target_link_libraries(vtcapture_backend vtcapture halgal yuv)
 
 add_library(dile_vt_backend SHARED
     src/backends/libdile_vt.c

--- a/src/backends/libvtcapture.c
+++ b/src/backends/libvtcapture.c
@@ -482,9 +482,9 @@ void capture_frame()
     else if (config.no_gui != 1 && config.no_video == 1) //GUI only
     {
         // ABGR -> ARGB
-        ABGRToARGB(guiABGR, w * 4, guiARGB, w * 4, w, h);
+        ABGRToARGB(guiABGR, surfaceInfo.width * 4, guiARGB, surfaceInfo.width * 4, surfaceInfo.width, surfaceInfo.height);
         // remove alpha channel
-        ARGBToRGB24(guiARGB, w * 4, outRGB, w * 3, w, h);
+        ARGBToRGB24(guiARGB, surfaceInfo.width * 4, outRGB, surfaceInfo.width * 3, surfaceInfo.width, surfaceInfo.height);
     }
     send_picture();
 

--- a/src/backends/libvtcapture.c
+++ b/src/backends/libvtcapture.c
@@ -457,7 +457,8 @@ void capture_frame()
     if(config.no_video != 1 && config.no_gui != 1 && vtcapture_initialized) //Both
     {
         // YUV -> ARGB
-        NV21ToARGB(videoY, stride, videoUV, stride, videoARGB, w * 4, w, h);
+        // NV21ToARGB(videoY, stride, videoUV, stride, videoARGB, w * 4, w, h);
+        NV21ToARGBMatrix(videoY, stride, videoUV, stride, videoARGB, w * 4, &kYuvH709Constants, w, h);
         // ABGR -> ARGB
         ABGRToARGB(guiABGR, w * 4, guiARGB, w * 4, w, h);
         // blend video and gui
@@ -475,7 +476,8 @@ void capture_frame()
     else if (config.no_video != 1 && config.no_gui == 1 && vtcapture_initialized) //Video only
     {
         // YUV -> RGB
-        NV21ToRGB24(videoY, stride, videoUV, stride, outRGB, w * 3, w, h);
+        // NV21ToRGB24(videoY, stride, videoUV, stride, outRGB, w * 3, w, h);
+        NV21ToRGB24Matrix(videoY, stride, videoUV, stride, outRGB, w * 3, &kYuvH709Constants, w, h);
     }
     else if (config.no_gui != 1 && config.no_video == 1) //GUI only
     {


### PR DESCRIPTION
Output of `libvtcapture` wasn't looking right: blacks too bright, whites too dark and colors a bit dull. 

So I replaced the lib's internal functions for YUV/ RGB conversion and blending with functions implemented in `libyuv` (just like `libdile_vt` is doing).

`NV21ToARGB()` and `NV21ToRGB24()` are using the BT.601 color space by default but standard on TVs should be BT.709 (and BT.2020 for HDR on capable TVs). When calling `NV21ToARGBMatrix()` and `NV21ToRGB24Matrix()` instead we are able to set the color space we want to use for conversion. So these functions are in place now and the color space is fixed to BT.709. We can talk about making the color space variable and selectable through the piccap-GUI... ;)

Additional:
- Gave the buffers in use telling names to make reviewing the code easier.
- Reduced size of the buffers because they allocated more space than needed. 4 times more to be precise because `sizeof(char *)` is 4 on 32-bit systems but `sizeof(char)` is only 1.
- Removed some unused variables.