### PR TITLE
Revert "libdile_vt: try CreateEx first"

### DIFF
--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -91,16 +91,11 @@ int capture_cleanup() {
 int capture_start()
 {
     INFO("Capture start called.");
+    vth = DILE_VT_Create(0);
 
-    if (&DILE_VT_CreateEx != 0) {
+    if (vth == NULL && &DILE_VT_CreateEx != 0) {
+        WARN("DILE_VT_Create failed, attempting DILE_VT_CreateEx");
         vth = DILE_VT_CreateEx(0, 1);
-        if (vth == NULL) {
-            WARN("DILE_VT_CreateEx failed, attempting DILE_VT_Create...");
-        }
-    }
-
-    if (vth == NULL) {
-        vth = DILE_VT_Create(0);
     }
 
     if (vth == NULL) {


### PR DESCRIPTION
This reverts commit b597246649548520dcf0ed864dd1eb39d1bc3f82.

Seems like K5LP sometimes succeeds to run CreateEx, but only emits a
single frame. Let's try this.