### PR TITLE
Fix building with buildroot toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,11 @@ add_executable(hyperion-webos
     src/hyperion_client.c
 )
 set_target_properties(hyperion-webos PROPERTIES
-    # BUILD_RPATH_USE_ORIGIN ON
-    # INSTALL_RPATH "$ORIGIN:$ORIGIN/lib"
-    # BUILD_RPATH "$ORIGIN:$ORIGIN/lib"
+    BUILD_RPATH_USE_ORIGIN ON
+    INSTALL_RPATH "$ORIGIN:$ORIGIN/lib"
+    BUILD_RPATH "$ORIGIN:$ORIGIN/lib"
     # TODO: use above options after upgrading to CMake 3.11
-    LINK_FLAGS "-Wl,-rpath,'$ORIGIN:$ORIGIN/lib' -Wl,-z,origin"
+    # LINK_FLAGS "-Wl,-rpath,'$ORIGIN:$ORIGIN/lib' -Wl,-z,origin"
 )
 target_include_directories(hyperion-webos PRIVATE fbs)
 target_link_libraries(hyperion-webos flatccrt pthread dl yuv ${GTHREAD2_LDFLAGS} ${PBNJSON_LDFLAGS} ${LS2_LDFLAGS} ${GLIB2_LDFLAGS} ${PMLOG_LDFLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ set_target_properties(hyperion-webos PROPERTIES
     # LINK_FLAGS "-Wl,-rpath,'$ORIGIN:$ORIGIN/lib' -Wl,-z,origin"
 )
 target_include_directories(hyperion-webos PRIVATE fbs)
-target_link_libraries(hyperion-webos flatccrt pthread dl yuv ${GTHREAD2_LDFLAGS} ${PBNJSON_LDFLAGS} ${LS2_LDFLAGS} ${GLIB2_LDFLAGS} ${PMLOG_LDFLAGS})
+target_link_libraries(hyperion-webos flatccrt pthread dl yuv rt ${GTHREAD2_LDFLAGS} ${PBNJSON_LDFLAGS} ${LS2_LDFLAGS} ${GLIB2_LDFLAGS} ${PMLOG_LDFLAGS})
 target_compile_options(hyperion-webos PRIVATE -Wextra -Wpedantic -Werror)
 set_property(TARGET hyperion-webos PROPERTY ENABLE_EXPORTS 1)
 
@@ -64,7 +64,7 @@ set_target_properties(unicapture-test PROPERTIES
     INSTALL_RPATH "$ORIGIN:$ORIGIN/lib"
     BUILD_RPATH "$ORIGIN:$ORIGIN/lib"
 )
-target_link_libraries(unicapture-test pthread dl yuv ${PMLOG_LDFLAGS})
+target_link_libraries(unicapture-test pthread dl yuv rt ${PMLOG_LDFLAGS})
 set_property(TARGET unicapture-test PROPERTY ENABLE_EXPORTS 1)
 
 # "Unified" v2 Backends

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set_target_properties(hyperion-webos PROPERTIES
 )
 target_include_directories(hyperion-webos PRIVATE fbs)
 target_link_libraries(hyperion-webos flatccrt pthread dl yuv ${GTHREAD2_LDFLAGS} ${PBNJSON_LDFLAGS} ${LS2_LDFLAGS} ${GLIB2_LDFLAGS} ${PMLOG_LDFLAGS})
-target_compile_options(hyperion-webos PRIVATE -Wall -Wextra -Wpedantic -Werror)
+target_compile_options(hyperion-webos PRIVATE -Wextra -Wpedantic -Werror)
 set_property(TARGET hyperion-webos PROPERTY ENABLE_EXPORTS 1)
 
 add_executable(unicapture-test

--- a/FLATBUFFERS.md
+++ b/FLATBUFFERS.md
@@ -1,0 +1,59 @@
+# Flatbuffers
+
+Flatcc: https://github.com/dvidelabs/flatcc
+
+This document describes how to update included flatbuffer files
+(library & auto generated packet definitions)
+
+## Preparation
+
+```sh
+# TODO: Adjust to your setup
+export TOOLCHAIN_FILE=<TOOLCHAIN_DIR>/arm-webos-linux-gnueabi_sdk-buildroot/share/buildroot/toolchainfile.cmake
+export HYPERION_WEBOS_DIR=<CHANGE ME>
+
+git clone https://github.com/dvidelabs/flatcc
+cd flatcc/
+```
+
+## Building the library
+
+```
+mkdir -p build/xbuild
+pushd ./build/xbuild
+
+cmake ../.. \
+ -DBUILD_SHARED_LIBS=on \
+ -DCMAKE_BUILD_TYPE=Release \
+ -DFLATCC_TEST=off \
+ -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}
+make
+
+popd
+
+# Copy built library
+cp ./lib/libflatccrt.a ${HYPERION_WEBOS_DIR}/flatccrt/lib/
+
+# Remove old and copy new headers
+rm -rf ${HYPERION_WEBOS_DIR}/flatccrt/include/flatcc
+cp -r ./include/flatcc ${HYPERION_WEBOS_DIR}/flatccrt/include/
+```
+
+## Generating the header files
+
+```sh
+mkdir -p build
+pushd build
+
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make
+
+popd
+
+# Generate headers
+./bin/flatcc ${HYPERION_WEBOS_DIR}/fbs/hyperion_request.fbs -w --common_reader --common_builder
+./bin/flatcc ${HYPERION_WEBOS_DIR}/fbs/hyperion_reply.fbs -w --common_reader --common_builder
+
+# Overwrite existing headers
+cp *.h ${HYPERION_WEBOS_DIR}/fbs/
+```

--- a/FLATBUFFERS.md
+++ b/FLATBUFFERS.md
@@ -23,7 +23,7 @@ mkdir -p build/xbuild
 pushd ./build/xbuild
 
 cmake ../.. \
- -DBUILD_SHARED_LIBS=on \
+ -DBUILD_SHARED_LIBS=off \
  -DCMAKE_BUILD_TYPE=Release \
  -DFLATCC_TEST=off \
  -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}

--- a/src/log.c
+++ b/src/log.c
@@ -53,7 +53,7 @@ void log_printf(LogLevel level, const char* module, const char* fmt, ...)
 
     vsnprintf(formatted + prefix, 1024 - prefix, fmt, args);
 
-    _PmLogMsgKV(context, level, 0, level == Debug ? NULL : level_str, 0, NULL, NULL, formatted);
+    _PmLogMsgKV(context, (PmLogLevel)level, 0, level == Debug ? NULL : level_str, 0, NULL, NULL, formatted);
 
     if (level <= current_log_level) {
         fprintf(stderr, "%10.3fs %s[%4s %-20s]\x1b[0m %s\n", (getticks_us() - start) / 1000000.0, color_str, level_str, module, formatted + prefix);

--- a/src/log.h
+++ b/src/log.h
@@ -6,6 +6,7 @@
 extern "C" {
 #endif
 
+// Shorthand for PmLogLevel: https://github.com/openwebos/pmloglib/blob/master/include/public/PmLogLib.h.in#L163
 typedef enum {
     Error = 3,
     Warning = 4,


### PR DESCRIPTION
To make it compatible with building with @ [arm-webos-linux-gnueabi_sdk-buildroot](https://github.com/openlgtv/buildroot-nc4/releases/tag/webos-9f5b1a1)

- [fix: Cast LogLevel enum into PmLogLevel](https://github.com/webosbrew/hyperion-webos/commit/69e4997eb03214be2f5d68139d207c2f941c7963)
- [Adjust target_properties for hyperion-webos for newer CMake version](https://github.com/webosbrew/hyperion-webos/commit/e5fb50698526811a1cfd54434fd283d72e06b314)
- [CMakeLists: Remove -Wall compiler-flag from hyperion-webos target](https://github.com/webosbrew/hyperion-webos/commit/b3b47d35174bb0e2b23d514f79de91472e82607e)
- [CMakeLists: Explicity link with librt for targets hyperion-webos/unicapture-test](https://github.com/webosbrew/hyperion-webos/commit/833fbb7563cc681164b827c396a36b8a871e64b4) 