### PR TITLE
Log levels, cmdline arg cleanup, add --dump-frames switch

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -25,14 +25,12 @@ static struct option long_options[] = {
     { "fps", required_argument, 0, 'f' },
     { "no-video", no_argument, 0, 'V' },
     { "no-gui", no_argument, 0, 'G' },
-    { "no-service", no_argument, 0, 'S' },
     { "no-vsync", no_argument, 0, 'n' },
     { "backend", required_argument, 0, 'b' },
     { "ui-backend", required_argument, 0, 'u' },
     { "help", no_argument, 0, 'h' },
     { "verbose", no_argument, 0, 'v' },
     { "config", required_argument, 0, 'c' },
-    { "save-conf", required_argument, 0, 's' },
     { "dump-frames", no_argument, 0, 'd' },
     { 0, 0, 0, 0 },
 };
@@ -44,7 +42,6 @@ static void print_usage()
     printf("Grab screen content continously and send to Hyperion via flatbuffers server.\n");
     printf("Application has to be named to hyperion-webos to avoid bugs!\n");
     printf("\n");
-    printf("  -S, --no-service      Run this from CLI and not as webOS-Service\n");
     printf("  -x, --width=WIDTH     Width of video frame (default 192)\n");
     printf("  -y, --height=HEIGHT   Height of video frame (default 108)\n");
     printf("  -a, --address=ADDR    IP address of Hyperion server\n");
@@ -56,7 +53,6 @@ static void print_usage()
     printf("  -G, --no-gui          GUI/UI will not be captured\n");
     printf("  -n, --no-vsync        Disable vsync (may increase framerate at the cost of tearing/artifacts)\n");
     printf("  -c, --config=PATH     Absolute path for configfile to load settings. Giving additional runtime arguments will overwrite loaded ones.\n");
-    printf("  -s, --save-conf=PATH  Saving configfile to given path.\n");
     printf("  -d, --dump-frames     Dump raw video frames to /tmp/.\n");
 }
 
@@ -65,7 +61,7 @@ static int parse_options(int argc, char* argv[])
     int opt, longindex;
     int ret;
 
-    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:u:c:s:vnhdSVG", long_options, &longindex)) != -1) {
+    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:u:c:vnhdVG", long_options, &longindex)) != -1) {
         switch (opt) {
         case 'x':
             settings.width = atoi(optarg);
@@ -89,10 +85,6 @@ static int parse_options(int argc, char* argv[])
         case 'G':
             settings.no_gui = 1;
             break;
-        case 'S':
-            // ???
-            // settings.no_service = 1;
-            break;
         case 'n':
             settings.vsync = false;
             break;
@@ -112,10 +104,6 @@ static int parse_options(int argc, char* argv[])
             if ((ret = settings_load_file(&settings, optarg)) != 0) {
                 WARN("Config load failed: %d", ret);
             }
-            break;
-        case 's':
-            // settings.save_settings = 1;
-            // _settingspath = strdup(optarg);
             break;
         case 'h':
             print_usage();

--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,7 @@ static struct option long_options[] = {
     { "verbose", no_argument, 0, 'v' },
     { "config", required_argument, 0, 'c' },
     { "save-conf", required_argument, 0, 's' },
+    { "dump-frames", no_argument, 0, 'd' },
     { 0, 0, 0, 0 },
 };
 
@@ -56,6 +57,7 @@ static void print_usage()
     printf("  -n, --no-vsync        Disable vsync (may increase framerate at the cost of tearing/artifacts)\n");
     printf("  -c, --config=PATH     Absolute path for configfile to load settings. Giving additional runtime arguments will overwrite loaded ones.\n");
     printf("  -s, --save-conf=PATH  Saving configfile to given path.\n");
+    printf("  -d, --dump-frames     Dump raw video frames to /tmp/.\n");
 }
 
 static int parse_options(int argc, char* argv[])
@@ -63,7 +65,7 @@ static int parse_options(int argc, char* argv[])
     int opt, longindex;
     int ret;
 
-    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:u:c:s:vnhSVG", long_options, &longindex)) != -1) {
+    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:u:c:s:vnhdSVG", long_options, &longindex)) != -1) {
         switch (opt) {
         case 'x':
             settings.width = atoi(optarg);

--- a/src/service.c
+++ b/src/service.c
@@ -67,6 +67,7 @@ int service_init(service_t* service, settings_t* settings)
     service->unicapture.fps = settings->fps;
     service->unicapture.callback = &service_feed_frame;
     service->unicapture.callback_data = (void*)service;
+    service->unicapture.dump_frames = settings->dump_frames;
 
     char* ui_backends[] = { "libgm_backend.so", "libhalgal_backend.so", NULL };
     char* video_backends[] = { "libvtcapture_backend.so", "libdile_vt_backend.so", NULL };

--- a/src/settings.c
+++ b/src/settings.c
@@ -18,6 +18,8 @@ void settings_init(settings_t* settings)
     settings->no_gui = false;
     settings->autostart = false;
     settings->vsync = true;
+
+    settings->dump_frames = false;
 }
 
 int settings_load_json(settings_t* settings, jvalue_ref source)

--- a/src/settings.h
+++ b/src/settings.h
@@ -24,6 +24,8 @@ typedef struct _settings_t {
     bool no_gui;
 
     bool autostart;
+
+    bool dump_frames;
 } settings_t;
 
 void settings_init(settings_t*);

--- a/src/unicapture.c
+++ b/src/unicapture.c
@@ -250,7 +250,7 @@ void* unicapture_run(void* data)
 
         uint64_t frame_processed = getticks_us();
 
-        if (got_frame && framecounter % 30 == 0) {
+        if (this->dump_frames && got_frame && framecounter % 30 == 0) {
             char filename[256];
             snprintf(filename, sizeof(filename), "/tmp/hyperion-webos-dump.%03d.data", (int)(framecounter / 30) % 10);
             FILE* fd = fopen(filename, "wb");

--- a/src/unicapture.c
+++ b/src/unicapture.c
@@ -281,13 +281,13 @@ void* unicapture_run(void* data)
             if (framecounter % 60 == 0) {
                 double fps = (60 * 1000000.0) / (getticks_us() - framecounter_start);
                 this->metrics.framerate = fps;
-                INFO("Framerate: %.6f FPS; timings - wait: %lldus, acquire: %lldus, convert: %lldus, process; %lldus, send: %lldus, release: %lldus",
+                DBG("Framerate: %.6f FPS; timings - wait: %lldus, acquire: %lldus, convert: %lldus, process; %lldus, send: %lldus, release: %lldus",
                     fps, frame_wait - frame_start, frame_acquired - frame_wait, frame_converted - frame_acquired, frame_processed - frame_converted, frame_sent - frame_processed, frame_released - frame_sent);
 
-                INFO("        UI: pixfmt: %d; %dx%d", ui_frame.pixel_format, ui_frame.width, ui_frame.height);
-                INFO("     VIDEO: pixfmt: %d; %dx%d", video_frame.pixel_format, video_frame.width, video_frame.height);
-                INFO("CONV    UI: pixfmt: %d; %dx%d", ui_frame_converted.pixel_format, ui_frame_converted.width, ui_frame_converted.height);
-                INFO("CONV VIDEO: pixfmt: %d; %dx%d", video_frame_converted.pixel_format, video_frame_converted.width, video_frame_converted.height);
+                DBG("        UI: pixfmt: %d; %dx%d", ui_frame.pixel_format, ui_frame.width, ui_frame.height);
+                DBG("     VIDEO: pixfmt: %d; %dx%d", video_frame.pixel_format, video_frame.width, video_frame.height);
+                DBG("CONV    UI: pixfmt: %d; %dx%d", ui_frame_converted.pixel_format, ui_frame_converted.width, ui_frame_converted.height);
+                DBG("CONV VIDEO: pixfmt: %d; %dx%d", video_frame_converted.pixel_format, video_frame_converted.width, video_frame_converted.height);
 
                 framecounter_start = getticks_us();
             }

--- a/src/unicapture.h
+++ b/src/unicapture.h
@@ -97,6 +97,8 @@ typedef struct _unicapture_state {
     unicapture_imagedata_callback_t callback;
     void* callback_data;
 
+    bool dump_frames;
+
     struct {
         double framerate;
     } metrics;


### PR DESCRIPTION
- [Change loglevel from INFO to DBG for framerate/timings/resolutions/pixelfmt](https://github.com/webosbrew/hyperion-webos/commit/e0562b7ea47161ae147e31dab87eed23c5c490fc) 

Example:
```
[INFO unicapture_run      ] Framerate: 9.240378 FPS; timings - wait: 10721us, acquire: 3047us, convert: 40502us, process; 475us, send: 38036us, release: 2us
[INFO unicapture_run      ]         UI: pixfmt: 11; 320x180
[INFO unicapture_run      ]      VIDEO: pixfmt: 0; 0x0
[INFO unicapture_run      ] CONV    UI: pixfmt: 12; 320x180
[INFO unicapture_run      ] CONV VIDEO: pixfmt: 0; 0x0
```

[Add CLI argument --dump-frames, to explicitly write raw data in /tmp/hyperion-webos-dump.%03d.data](https://github.com/webosbrew/hyperion-webos/commit/e92933312dd1dc7963c69d709352f6bcf3d6d928) 

The flag "--dump-frames" is only available via CLI invocation, not via service's /setSettings, to just use it for explicit debug purposes.

[Remove --save-conf and --no-service cmdline flags](https://github.com/webosbrew/hyperion-webos/commit/92aa724f691a0253fb0c370269ed90102af2a958) 

* --save-conf is obsolete, settings json is saved when service-endpoint `/setSettings` gets invoked
* --no-service is obsolete, auto-detection of environment (CLI or luna-service) is done by checking env-variable `LS_SERVICE_NAMES`