### PR TITLE
[DILE_VT] WebOS 3.4.0 Undocumented dump location 2

### DIFF
--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -67,9 +67,13 @@ int capture_init(cap_backend_config_t* config, void** state_p)
         WARN("[DILE_VT] DISPLAY dump location failed, attempting SCALER...");
         dump_location = DILE_VT_SCALER_OUTPUT;
         if (DILE_VT_SetVideoFrameOutputDeviceDumpLocation(vth, dump_location) != 0) {
-            ERR("[DILE_VT] SetVideoFrameOutputDeviceDumpLocation failed!");
-            ret = -2;
-            goto err_destroy;
+            ERR("[DILE_VT] SCALER dump location failed, attempting UNDOCUMENTED DUMP LOCATION: 2!");
+            dump_location = 2;
+            if (DILE_VT_SetVideoFrameOutputDeviceDumpLocation(vth, dump_location) != 0) {
+                ERR("[DILE_VT] SetVideoFrameOutputDeviceDumpLocation failed!");
+                ret = -2;
+                goto err_destroy;
+            }
         }
     }
 


### PR DESCRIPTION
If `DILE_VT_DSIPLAY_OUTPUT` and `DILE_VT_SCALER_OUTPUT` fail to init `SetVideoFrameOutputDeviceDumpLocation` - fallback to undocumented value `2`.