### PR TITLE
Build git-tag / commit-hash into binary, fix `--dump-frames` argument, add 'version' info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,14 @@ include_directories(${PMLOG_INCLUDE_DIRS})
 pkg_check_modules(EGL egl REQUIRED)
 pkg_check_modules(GLESv2 glesv2 REQUIRED)
 
+find_package(Git)
+add_custom_target(version
+  ${CMAKE_COMMAND} -D SRC=${CMAKE_SOURCE_DIR}/src/version.h.in
+                   -D DST=${CMAKE_BINARY_DIR}/version.h
+                   -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
+                   -P ${CMAKE_SOURCE_DIR}/GenerateVersionHeader.cmake
+)
+
 add_executable(hyperion-webos
     src/main.c
     src/settings.c
@@ -47,8 +55,9 @@ set_target_properties(hyperion-webos PROPERTIES
     # TODO: use above options after upgrading to CMake 3.11
     # LINK_FLAGS "-Wl,-rpath,'$ORIGIN:$ORIGIN/lib' -Wl,-z,origin"
 )
-target_include_directories(hyperion-webos PRIVATE fbs)
+target_include_directories(hyperion-webos PRIVATE fbs ${CMAKE_BINARY_DIR})
 target_link_libraries(hyperion-webos flatccrt pthread dl yuv rt ${GTHREAD2_LDFLAGS} ${PBNJSON_LDFLAGS} ${LS2_LDFLAGS} ${GLIB2_LDFLAGS} ${PMLOG_LDFLAGS})
+add_dependencies(hyperion-webos version)
 target_compile_options(hyperion-webos PRIVATE -Wextra -Wpedantic -Werror)
 set_property(TARGET hyperion-webos PROPERTY ENABLE_EXPORTS 1)
 

--- a/GenerateVersionHeader.cmake
+++ b/GenerateVersionHeader.cmake
@@ -1,0 +1,23 @@
+if(GIT_EXECUTABLE)
+  get_filename_component(SRC_DIR ${SRC} DIRECTORY)
+  # Generate a git-describe version string from Git repository tags
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --all --long --dirty
+    WORKING_DIRECTORY ${SRC_DIR}
+    OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
+    RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  if(NOT GIT_DESCRIBE_ERROR_CODE)
+    set(HYPERION_WEBOS_VERSION ${GIT_DESCRIBE_VERSION})
+  endif()
+endif()
+
+# Final fallback: Just use a bogus version string that is semantically older
+# than anything else and spit out a warning to the developer.
+if(NOT DEFINED HYPERION_WEBOS_VERSION)
+  set(HYPERION_WEBOS_VERSION v0.0.0-unknown)
+  message(WARNING "Failed to determine HYPERION_WEBOS_VERSION from Git tags. Using default version \"${HYPERION_WEBOS_VERSION}\".")
+endif()
+
+configure_file(${SRC} ${DST} @ONLY)

--- a/src/main.c
+++ b/src/main.c
@@ -141,7 +141,7 @@ int main(int argc, char* argv[])
     int ret;
 
     log_init();
-    INFO("Starting up...");
+    INFO("Starting up (version: %s)...", HYPERION_WEBOS_VERSION);
 
     using_cli = !getenv("LS_SERVICE_NAMES");
 

--- a/src/main.c
+++ b/src/main.c
@@ -88,6 +88,9 @@ static int parse_options(int argc, char* argv[])
         case 'n':
             settings.vsync = false;
             break;
+        case 'd':
+            settings.dump_frames = true;
+            break;
         case 'v':
             log_set_level(Debug);
             break;

--- a/src/main.c
+++ b/src/main.c
@@ -4,12 +4,14 @@
 #include "log.h"
 #include "service.h"
 #include "settings.h"
+#include "version.h"
 
 GMainLoop* loop;
 
 settings_t settings;
 service_t service;
 bool using_cli = false;
+int print_version = 0;
 
 void int_handler(int signum __attribute__((unused)))
 {
@@ -30,6 +32,7 @@ static struct option long_options[] = {
     { "ui-backend", required_argument, 0, 'u' },
     { "help", no_argument, 0, 'h' },
     { "verbose", no_argument, 0, 'v' },
+    { "version", no_argument, &print_version, 1 },
     { "config", required_argument, 0, 'c' },
     { "dump-frames", no_argument, 0, 'd' },
     { 0, 0, 0, 0 },
@@ -54,6 +57,10 @@ static void print_usage()
     printf("  -n, --no-vsync        Disable vsync (may increase framerate at the cost of tearing/artifacts)\n");
     printf("  -c, --config=PATH     Absolute path for configfile to load settings. Giving additional runtime arguments will overwrite loaded ones.\n");
     printf("  -d, --dump-frames     Dump raw video frames to /tmp/.\n");
+    printf("\n");
+    printf("  -v, --verbose         Enable verbose logging.\n");
+    printf("  -h, --help            Print this list of arguments.\n");
+    printf("  --version             Print program version.\n");
 }
 
 static int parse_options(int argc, char* argv[])
@@ -111,6 +118,9 @@ static int parse_options(int argc, char* argv[])
         case 'h':
             print_usage();
             return 1;
+        case 0:
+            /* getopt_long() set a variable, just keep going */
+            break;
         default:
             WARN("Unknown option: %c", opt);
             print_usage();
@@ -119,6 +129,11 @@ static int parse_options(int argc, char* argv[])
     }
 
     return 0;
+}
+
+void print_version_string()
+{
+    fprintf(stderr, "%s\n", HYPERION_WEBOS_VERSION);
 }
 
 int main(int argc, char* argv[])
@@ -141,6 +156,11 @@ int main(int argc, char* argv[])
 
     if ((ret = parse_options(argc, argv)) != 0) {
         return ret;
+    }
+
+    if (print_version > 0) {
+        print_version_string();
+        return 0;
     }
 
     signal(SIGINT, int_handler);

--- a/src/service.c
+++ b/src/service.c
@@ -4,6 +4,7 @@
 #include "pthread.h"
 #include "settings.h"
 #include "unicapture.h"
+#include "version.h"
 #include <errno.h>
 #include <luna-service2/lunaservice.h>
 #include <stdio.h>
@@ -197,6 +198,7 @@ bool service_method_status(LSHandle* sh, LSMessage* msg, void* data)
 
     jobject_set(jobj, j_cstr_to_buffer("returnValue"), jboolean_create(true));
     jobject_set(jobj, j_cstr_to_buffer("elevated"), jboolean_create(getuid() == 0));
+    jobject_set(jobj, j_cstr_to_buffer("version"), jstring_create(HYPERION_WEBOS_VERSION));
     jobject_set(jobj, j_cstr_to_buffer("isRunning"), jboolean_create(service->running));
     jobject_set(jobj, j_cstr_to_buffer("connected"), jboolean_create(service->connected));
     jobject_set(jobj, j_cstr_to_buffer("videoBackend"), service->video_backend.name ? jstring_create(service->video_backend.name) : jnull());

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define HYPERION_WEBOS_VERSION "@HYPERION_WEBOS_VERSION@"


### PR DESCRIPTION
- [CMake: Use git-describe to create version.h](https://github.com/webosbrew/hyperion-webos/commit/464313b3937a143a1443ecb6aceeaea93b979529)
 
- [service: Return version in /status endpoint](https://github.com/webosbrew/hyperion-webos/commit/7e8756a0fb6974c424d48b7c5906a21c017b38d6)

- [CLI: Fix --dump-frames argument parsing](https://github.com/webosbrew/hyperion-webos/commit/4bccbd0c44f0a3051c03338179a61196915c02cc)

- [CLI: Implement --version argument](https://github.com/webosbrew/hyperion-webos/commit/e300564920c2a88abcd3071f38270049a90c34ac)

Implements #71 