### PR TITLE
Fix: Flickering due to powerstate callback

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -317,7 +317,7 @@ static bool power_callback(LSHandle* sh __attribute__((unused)), LSMessage* msg,
 
     raw_buffer state_buf = jstring_get(state_ref);
     const char* state_str = state_buf.m_str;
-    bool target_state = strcmp(state_str, "Active") == 0 && !jobject_containskey(parsed, j_cstr_to_buffer("processing"));
+    bool target_state = strcmp(state_str, "Active") == 0;
 
     if (!service->running && target_state && service->power_paused) {
         INFO("Resuming after power pause...");


### PR DESCRIPTION
Ignore the existance of 'processing' field as some TVs use it for checking screensaver state.
This causes a short flickering in LED strips because unicapture will stop/start for a brief period.

Just checking for 'state' == 'Active' seems fine tho.

```
This shows up randomly and leads to hyperion-webos switch off/on:
{ "returnValue": true, "state": "Active", "processing": "Request Screen Saver" }
{ "returnValue": true, "state": "Active", "processing": "Screen On" }
{ "returnValue": true, "state": "Active" }

PowerOff:
{ "returnValue": true, "state": "Active", "processing": "Request Power Off", "onOff": "off", "reason": "remoteKey" }
{ "returnValue": true, "state": "Active", "processing": "Request Active Standby", "onOff": "off", "reason": "remoteKey" }
{ "returnValue": true, "state": "Active", "processing": "Prepare Active Standby", "onOff": "off", "reason": "remoteKey" }
{ "returnValue": true, "state": "Active Standby" }
{ "returnValue": true, "state": "Active Standby", "processing": "Request Suspend", "onOff": "off", "reason": "homekit" }
{ "returnValue": true, "state": "Active Standby", "processing": "Prepare Suspend", "onOff": "off", "reason": "homekit" }
{ "returnValue": true, "state": "Suspend" }

PowerOn:
{ "returnValue": true, "state": "Suspend", "processing": "Prepare Resume", "onOff": "on", "reason": "remoteKey" }
{ "returnValue": true, "state": "Suspend", "processing": "LastInput Ready", "onOff": "on", "reason": "remoteKey" }
{ "returnValue": true, "state": "Suspend", "processing": "Screen On", "onOff": "on", "reason": "remoteKey" }
{ "returnValue": true, "state": "Active" }
```