### PR TITLE
Feature: Implement quirks

### DIFF
--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -33,11 +33,11 @@ int capture_init(cap_backend_config_t* config, void** state_p)
 
     INFO("Capture start called.");
 
-    if HAS_QUIRK(config->quirks, QUIRK_DILE_VT_CREATE_EX) {
+    if (HAS_QUIRK(config->quirks, QUIRK_DILE_VT_CREATE_EX)) {
         INFO("[QUIRK_DILE_VT_CREATE_EX]: Attempting DILE_VT_CreateEx...");
         vth = DILE_VT_CreateEx(0, 1);
     } else {
-        INFO("Attempting DILE_VT...");
+        INFO("Attempting DILE_VT_Create...");
         vth = DILE_VT_Create(0);
     }
 

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -14,6 +14,7 @@
 
 #include "log.h"
 #include "unicapture.h"
+#include "quirks.h"
 #include "utils.h"
 
 typedef struct _dile_vt_backend_state {
@@ -32,11 +33,12 @@ int capture_init(cap_backend_config_t* config, void** state_p)
 
     INFO("Capture start called.");
 
-    vth = DILE_VT_Create(0);
-
-    if (vth == NULL && &DILE_VT_CreateEx != 0) {
-        WARN("DILE_VT_Create failed, attempting DILE_VT_CreateEx...");
+    if HAS_QUIRK(config->quirks, QUIRK_DILE_VT_CREATE_EX) {
+        INFO("[QUIRK_DILE_VT_CREATE_EX]: Attempting DILE_VT_CreateEx...");
         vth = DILE_VT_CreateEx(0, 1);
+    } else {
+        INFO("Attempting DILE_VT...");
+        vth = DILE_VT_Create(0);
     }
 
     if (vth == NULL) {

--- a/src/common.h
+++ b/src/common.h
@@ -17,6 +17,7 @@ typedef struct _cap_backend_config {
     int framedelay_us;
     int resolution_width;
     int resolution_height;
+    int quirks;
     bool no_video;
     bool no_gui;
     bool save_config;

--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,7 @@ static struct option long_options[] = {
     { "no-vsync", no_argument, 0, 'n' },
     { "backend", required_argument, 0, 'b' },
     { "ui-backend", required_argument, 0, 'u' },
+    { "quirks", required_argument, 0, 'q' },
     { "help", no_argument, 0, 'h' },
     { "verbose", no_argument, 0, 'v' },
     { "version", no_argument, &print_version, 1 },
@@ -55,6 +56,7 @@ static void print_usage()
     printf("  -V, --no-video        Video will not be captured\n");
     printf("  -G, --no-gui          GUI/UI will not be captured\n");
     printf("  -n, --no-vsync        Disable vsync (may increase framerate at the cost of tearing/artifacts)\n");
+    printf("  -q, --quirks=QUIRKS   Enable certain handling for per-device quirks\n");
     printf("  -c, --config=PATH     Absolute path for configfile to load settings. Giving additional runtime arguments will overwrite loaded ones.\n");
     printf("  -d, --dump-frames     Dump raw video frames to /tmp/.\n");
     printf("\n");
@@ -68,7 +70,7 @@ static int parse_options(int argc, char* argv[])
     int opt, longindex;
     int ret;
 
-    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:u:c:vnhdVG", long_options, &longindex)) != -1) {
+    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:u:q:c:vnhdVG", long_options, &longindex)) != -1) {
         switch (opt) {
         case 'x':
             settings.width = atoi(optarg);
@@ -108,6 +110,9 @@ static int parse_options(int argc, char* argv[])
         case 'u':
             free(settings.ui_backend);
             settings.ui_backend = strdup(optarg);
+            break;
+        case 'q':
+            settings.quirks = atoi(optarg);
             break;
         case 'c':
             DBG("Loading config file %s...", optarg);

--- a/src/quirks.h
+++ b/src/quirks.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#define HAS_QUIRK(quirk_val, enum_val) ((quirk_val & enum_val) == enum_val)
+
+enum CAPTURE_QUIRKS {
+    QUIRK_DILE_VT_CREATE_EX = 0x1
+};

--- a/src/service.c
+++ b/src/service.c
@@ -60,6 +60,7 @@ int service_init(service_t* service, settings_t* settings)
     config.resolution_width = settings->width;
     config.resolution_height = settings->height;
     config.fps = settings->fps;
+    config.quirks = settings->quirks;
 
     service->settings = settings;
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -13,6 +13,7 @@ void settings_init(settings_t* settings)
     settings->fps = 30;
     settings->width = 320;
     settings->height = 180;
+    settings->quirks = 0;
 
     settings->no_video = false;
     settings->no_gui = false;
@@ -57,6 +58,8 @@ int settings_load_json(settings_t* settings, jvalue_ref source)
         jnumber_get_i32(value, &settings->width);
     if ((value = jobject_get(source, j_cstr_to_buffer("height"))) && jis_number(value))
         jnumber_get_i32(value, &settings->height);
+    if ((value = jobject_get(source, j_cstr_to_buffer("quirks"))) && jis_number(value))
+        jnumber_get_i32(value, &settings->quirks);
 
     if ((value = jobject_get(source, j_cstr_to_buffer("vsync"))) && jis_boolean(value))
         jboolean_get(value, &settings->vsync);
@@ -82,6 +85,7 @@ int settings_save_json(settings_t* settings, jvalue_ref target)
     jobject_set(target, j_cstr_to_buffer("fps"), jnumber_create_i32(settings->fps));
     jobject_set(target, j_cstr_to_buffer("width"), jnumber_create_i32(settings->width));
     jobject_set(target, j_cstr_to_buffer("height"), jnumber_create_i32(settings->height));
+    jobject_set(target, j_cstr_to_buffer("quirks"), jnumber_create_i32(settings->height));
 
     jobject_set(target, j_cstr_to_buffer("vsync"), jboolean_create(settings->vsync));
     jobject_set(target, j_cstr_to_buffer("novideo"), jboolean_create(settings->no_video));

--- a/src/settings.c
+++ b/src/settings.c
@@ -85,7 +85,7 @@ int settings_save_json(settings_t* settings, jvalue_ref target)
     jobject_set(target, j_cstr_to_buffer("fps"), jnumber_create_i32(settings->fps));
     jobject_set(target, j_cstr_to_buffer("width"), jnumber_create_i32(settings->width));
     jobject_set(target, j_cstr_to_buffer("height"), jnumber_create_i32(settings->height));
-    jobject_set(target, j_cstr_to_buffer("quirks"), jnumber_create_i32(settings->height));
+    jobject_set(target, j_cstr_to_buffer("quirks"), jnumber_create_i32(settings->quirks));
 
     jobject_set(target, j_cstr_to_buffer("vsync"), jboolean_create(settings->vsync));
     jobject_set(target, j_cstr_to_buffer("novideo"), jboolean_create(settings->no_video));

--- a/src/settings.h
+++ b/src/settings.h
@@ -19,6 +19,7 @@ typedef struct _settings_t {
     int width;
     int height;
     bool vsync;
+    int quirks;
 
     bool no_video;
     bool no_gui;


### PR DESCRIPTION
For specific device quirks, implement the setting `quirks` which takes a numeric value consisting of bitflags which configure special handling of capture backends and its not possible to handle this case at runtime.

For example devices that use `DILE_VT` but require calling `DILE_VT_CreateEx` instead of `DILE_VT_Create`, use `{"quirks":1}`.

Currently there is only one known quirk:
```c
enum CAPTURE_QUIRKS {
    QUIRK_DILE_VT_CREATE_EX = 0x1
};
```

Checking is done via:

`HAS_QUIRK(quirks_value, quirks_enum)` 

Example

```c
if(HAS_QUIRK(config->quirks, QUIRK_DILE_VT_CREATE_EX)) {
  // ... run special routine
} else {
  // ... run regular routine
}
```

NOTE for the enduser regarding bitflags:

When we have three quirks, like this:

```c
enum CAPTURE_QUIRKS {
    QUIRK_DILE_VT_CREATE_EX = 0x1,
    QUIRK_SOMETHING_ELSE =    0x2,
    QUIRK_SOMETHING_ELSE2 =   0x4,
    ...
    QUIRK_SOMETHING_ELSE8 = 0x100,
    QUIRK_SOMETHING_ELSE9 = 0x200,
};
```

To create the final value to set for quirks you do an `OR` operation on these:

```
quirks = (QUIRK_DILE_VT_CREATE_EX | QUIRK_SOMETHING_ELSE9)
```