### PR TITLE
DILE_VT/Quirks: Implement QUIRK_DILE_VT_NO_FREEZE_CAPTURE

### DIFF
--- a/src/quirks.h
+++ b/src/quirks.h
@@ -3,5 +3,6 @@
 #define HAS_QUIRK(quirk_val, enum_val) ((quirk_val & enum_val) == enum_val)
 
 enum CAPTURE_QUIRKS {
-    QUIRK_DILE_VT_CREATE_EX = 0x1
+    QUIRK_DILE_VT_CREATE_EX = 0x1,
+    QUIRK_DILE_VT_NO_FREEZE_CAPTURE = 0x2
 };


### PR DESCRIPTION
Do not wait for DILE_VT_SetVideoFrameOutputDeviceState: FREEZED in capture_acquire_frame

* It is not compatible with every TV, hence implementing it as a *quirk*
* Yields alot higher FPS for me (went from 8 fps -> 50 fps)