### PR TITLE
quirks: Add QUIRK_DILE_VT_DUMP_LOCATION_2 (0x4)

### DIFF
--- a/src/quirks.h
+++ b/src/quirks.h
@@ -4,5 +4,10 @@
 
 enum CAPTURE_QUIRKS {
     QUIRK_DILE_VT_CREATE_EX = 0x1,
-    QUIRK_DILE_VT_NO_FREEZE_CAPTURE = 0x2
+    QUIRK_DILE_VT_NO_FREEZE_CAPTURE = 0x2,
+    /* (WebOS 3.4) Use undocumented DUMP LOCATION 2 for
+       DILE_VT_SetVideoFrameOutputDeviceDumpLocation and
+       DILE_VT_SetVideoFrameOutputDeviceOutputRegion
+    */
+    QUIRK_DILE_VT_DUMP_LOCATION_2 = 0x4
 };


### PR DESCRIPTION
Mostly for WebOS 3.4 - this path was taken as last resort before, but turned out, this value (0x2) as dump_location is required to be taken first, to produce reliable results.

(PR #79 is also updated in that regard) 