### PR TITLE
Add local unix socket support

### DIFF
--- a/src/hyperion_client.h
+++ b/src/hyperion_client.h
@@ -1,6 +1,7 @@
 #pragma once
+#include <stdbool.h>
 
-int hyperion_client(const char* origin, const char* hostname, int port, int priority);
+int hyperion_client(const char* origin, const char* hostname, int port, bool unix_socket, int priority);
 int hyperion_read();
 int hyperion_destroy();
 int hyperion_set_image(const unsigned char* image, int width, int height);

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@ static struct option long_options[] = {
     { "height", required_argument, 0, 'y' },
     { "address", required_argument, 0, 'a' },
     { "port", required_argument, 0, 'p' },
+    { "unix-socket", no_argument, 0, 'l' },
     { "fps", required_argument, 0, 'f' },
     { "no-video", no_argument, 0, 'V' },
     { "no-gui", no_argument, 0, 'G' },
@@ -50,6 +51,7 @@ static void print_usage()
     printf("  -y, --height=HEIGHT   Height of video frame (default 108)\n");
     printf("  -a, --address=ADDR    IP address of Hyperion server\n");
     printf("  -p, --port=PORT       Port of Hyperion flatbuffers server (default 19400)\n");
+    printf("  -l, --unix-socket     Connect through unix socket\n");
     printf("  -f, --fps=FPS         Framerate for sending video frames (default 0 = unlimited)\n");
     printf("  -b, --backend=BE      Use specific video capture backend (default auto)\n");
     printf("  -u, --ui-backend=BE   Use specific ui capture backend (default auto)\n");
@@ -70,7 +72,7 @@ static int parse_options(int argc, char* argv[])
     int opt, longindex;
     int ret;
 
-    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:u:q:c:vnhdVG", long_options, &longindex)) != -1) {
+    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:u:q:c:lvnhdVG", long_options, &longindex)) != -1) {
         switch (opt) {
         case 'x':
             settings.width = atoi(optarg);
@@ -84,6 +86,9 @@ static int parse_options(int argc, char* argv[])
             break;
         case 'p':
             settings.port = atol(optarg);
+            break;
+        case 'l':
+            settings.unix_socket = true;
             break;
         case 'f':
             settings.fps = atoi(optarg);

--- a/src/service.c
+++ b/src/service.c
@@ -28,7 +28,8 @@ void* connection_loop(void* data)
     DBG("Starting connection loop");
     while (service->connection_loop_running) {
         INFO("Connecting hyperion-client..");
-        if ((hyperion_client("webos", service->settings->address, service->settings->port, service->settings->priority)) != 0) {
+        if ((hyperion_client("webos", service->settings->address, service->settings->port,
+                             service->settings->unix_socket, service->settings->priority)) != 0) {
             ERR("Error! hyperion_client.");
         } else {
             INFO("hyperion-client connected!");
@@ -407,7 +408,7 @@ static bool videooutput_callback(LSHandle* sh __attribute__((unused)), LSMessage
         hdr_enabled = true;
     }
 
-    int ret = set_hdr_state(service->settings->address, RPC_PORT, hdr_enabled);
+    int ret = set_hdr_state(service->settings->unix_socket ? "127.0.0.1" : service->settings->address, RPC_PORT, hdr_enabled);
     if (ret != 0) {
         ERR("videooutput_callback: set_hdr_state failed, ret: %d", ret);
     }
@@ -459,7 +460,7 @@ static bool picture_callback(LSHandle* sh __attribute__((unused)), LSMessage* ms
         hdr_enabled = true;
     }
 
-    int ret = set_hdr_state(service->settings->address, RPC_PORT, hdr_enabled);
+    int ret = set_hdr_state(service->settings->unix_socket ? "127.0.0.1" : service->settings->address, RPC_PORT, hdr_enabled);
     if (ret != 0) {
         ERR("videooutput_callback: set_hdr_state failed, ret: %d", ret);
     }

--- a/src/settings.c
+++ b/src/settings.c
@@ -9,6 +9,7 @@ void settings_init(settings_t* settings)
     settings->address = strdup("");
     settings->port = 19400;
     settings->priority = 150;
+    settings->unix_socket = false;
 
     settings->fps = 30;
     settings->width = 320;
@@ -51,6 +52,8 @@ int settings_load_json(settings_t* settings, jvalue_ref source)
         jnumber_get_i32(value, &settings->port);
     if ((value = jobject_get(source, j_cstr_to_buffer("priority"))) && jis_number(value))
         jnumber_get_i32(value, &settings->priority);
+    if ((value = jobject_get(source, j_cstr_to_buffer("unix-socket"))) && jis_boolean(value))
+        jboolean_get(value, &settings->unix_socket);
 
     if ((value = jobject_get(source, j_cstr_to_buffer("fps"))) && jis_number(value))
         jnumber_get_i32(value, &settings->fps);
@@ -81,6 +84,7 @@ int settings_save_json(settings_t* settings, jvalue_ref target)
     jobject_set(target, j_cstr_to_buffer("address"), jstring_create(settings->address));
     jobject_set(target, j_cstr_to_buffer("port"), jnumber_create_i32(settings->port));
     jobject_set(target, j_cstr_to_buffer("priority"), jnumber_create_i32(settings->priority));
+    jobject_set(target, j_cstr_to_buffer("unix-socket"), jboolean_create(settings->unix_socket));
 
     jobject_set(target, j_cstr_to_buffer("fps"), jnumber_create_i32(settings->fps));
     jobject_set(target, j_cstr_to_buffer("width"), jnumber_create_i32(settings->width));

--- a/src/settings.h
+++ b/src/settings.h
@@ -14,6 +14,7 @@ typedef struct _settings_t {
     char* address;
     int port;
     int priority;
+    bool unix_socket;
 
     int fps;
     int width;


### PR DESCRIPTION
Local unix socket support was added in HyperHDR in https://github.com/awawa-dev/HyperHDR/commit/1100093068196a53eff5f856f0eaaf8e43ca229f

Local unix sockets are automatically used when the hostname is set to "/tmp/hyperhdr-domain" which is hardcoded in HyperHDR. On my TV local sockets are around 20-30% faster.