### PR TITLE
Unicapture: Fix service register on newer TVs & VTC init at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Currently the following ones exist:
 | DILE_VT   | QUIRK_DILE_VT_CREATE_EX | Use `DILE_VT_CreateEx` instead of `DILE_VT_Create`  | 0x1  |
 | DILE_VT   | QUIRK_DILE_VT_NO_FREEZE_CAPTURE | Do not freeze frame before capturing (higher fps) | 0x2 |
 | DILE_VT   | QUIRK_DILE_VT_DUMP_LOCATION_2   | (webOS 3.4) Use undocumented dump location 2 | 0x4  |
+| VTCAPTURE   | QUIRK_VTCAPTURE_K6HP_FORCE_CAPTURE   | Use of a custom kernel module for reenable capture in special situation | 0x8  |
 
 
 They can be provided in `config.json` via the `{"quirks": 0}` field or on commandline via `--quirks`.

--- a/src/backends/libvtcapture.cpp
+++ b/src/backends/libvtcapture.cpp
@@ -261,6 +261,10 @@ int capture_wait(void* state)
                 return -99; //Restart video capture
             }
             return -1;
+        } else if (ret == 12) {
+            ERR("vtCapture_currentCaptureBuffInfo() failed: %d", ret);
+            DBG("Returning with video capture stop (-99), to get restarted in next routine.");
+            return -99; //Restart video capture
         } else if (ret != 0) {
 
             ERR("vtCapture_currentCaptureBuffInfo() failed: %d", ret);

--- a/src/backends/libvtcapture.cpp
+++ b/src/backends/libvtcapture.cpp
@@ -2,11 +2,18 @@
 #include <stdlib.h> // calloc()
 #include <unistd.h> // usleep()
 
+#include <fcntl.h>
+#include <sys/ioctl.h> //ioctl
+
 #include "log.h"
 #include "unicapture.h"
+#include "quirks.h"
 
 extern "C" {
 #include <vtcapture/vtCaptureApi_c.h>
+
+#define FCI_MAGIC 'Z'
+#define FC_K6HP _IO(FCI_MAGIC, 0)
 
 typedef struct _vtcapture_backend_state {
     int width;
@@ -18,6 +25,7 @@ typedef struct _vtcapture_backend_state {
     _LibVtCaptureProperties props;
     char* curr_buff;
     bool terminate;
+    bool quirk_force_capture;
 } vtcapture_backend_state_t;
 
 int capture_terminate(void* state);
@@ -37,8 +45,6 @@ int capture_init(cap_backend_config_t* config, void** state_p)
             goto err_destroy;
         }
     } catch (const std::runtime_error& err) {
-        WARN("vtCapture_create() failed: %s", err.what());
-        ret = -2;
         goto err_destroy;
     }
 
@@ -52,6 +58,10 @@ int capture_init(cap_backend_config_t* config, void** state_p)
     self->props.reg.w = config->resolution_width;
     self->props.reg.h = config->resolution_height;
     self->props.buf_cnt = 3;
+
+    if (HAS_QUIRK(config->quirks, QUIRK_VTCAPTURE_FORCE_CAPTURE)) {
+        self->quirk_force_capture = true;
+    }
 
     *state_p = self;
 
@@ -89,16 +99,34 @@ int capture_start(void* state)
     if ((ret = vtCapture_init(self->driver, caller, self->client)) == 17) {
 
         ERR("vtCapture_init not ready yet return: %d", ret);
+        //Quirk
+        if (self->quirk_force_capture) {
+            int fd;
+    
+            DBG("Quirk enabled. Open /dev/forcecapture");
+            fd = open("/dev/forcecapture", O_RDWR);
+            if(fd < 0) {
+                    ERR("Can't open /dev/forcecapture!");
+                    ret = -2;
+                    goto err_init;
+            }
+    
+            INFO("QUIRK_VTCAPTURE_FORCE_CAPTURE: Calling interface with FC_K6HP");
+            ioctl(fd, FC_K6HP); 
+    
+            DBG("Closing /dev/forcecapture");
+            close(fd);
+        }
         ret = -2;
         goto err_init;
     } else if (ret == 11) {
 
-        ERR("vtCapture_init failed: %d Permission denied! Quitting...", ret);
+        ERR("vtCapture_init failed: %d Permission denied!", ret);
         ret = -3;
         goto err_init;
     } else if (ret != 0) {
 
-        ERR("vtCapture_init failed: %d Quitting...", ret);
+        ERR("vtCapture_init failed: %d", ret);
         ret = -4;
         goto err_init;
     }
@@ -110,16 +138,16 @@ int capture_start(void* state)
         ret = -5;
         goto err_preprocess;
     } else if (ret != 0) {
-        ERR("vtCapture_preprocess failed: %x Quitting...", ret);
+        ERR("vtCapture_preprocess failed: %d", ret);
         ret = -6;
         goto err_preprocess;
     }
     INFO("vtCapture_preprocess done!");
 
     _LibVtCapturePlaneInfo plane;
-    if ((vtCapture_planeInfo(self->driver, self->client, &plane)) != 0) {
+    if ((ret = vtCapture_planeInfo(self->driver, self->client, &plane)) != 0) {
 
-        ERR("vtCapture_planeInfo failed: %xQuitting...", ret);
+        ERR("vtCapture_planeInfo failed: %d", ret);
         ret = -7;
         goto err_planeinfo;
     }
@@ -136,9 +164,9 @@ int capture_start(void* state)
 
     INFO("vtcapture initialization finished.");
 
-    if ((vtCapture_process(self->driver, self->client)) != 0) {
+    if ((ret = vtCapture_process(self->driver, self->client)) != 0) {
 
-        ERR("vtCapture_process failed: %xQuitting...", ret);
+        ERR("vtCapture_process failed: %d", ret);
         ret = -1;
         goto err_process;
     }
@@ -176,10 +204,11 @@ int capture_acquire_frame(void* state, frame_info_t* frame)
 {
     vtcapture_backend_state_t* self = (vtcapture_backend_state_t*)state;
     _LibVtCaptureBufferInfo buff;
+    int ret = 0;
 
-    if (vtCapture_currentCaptureBuffInfo(self->driver, &buff) != 0) {
+    if ((ret = vtCapture_currentCaptureBuffInfo(self->driver, &buff)) != 0) {
 
-        ERR("vtCapture_currentCaptureBuffInfo() failed.");
+        ERR("vtCapture_currentCaptureBuffInfo() failed: %d", ret);
         return -1;
     }
 
@@ -205,12 +234,36 @@ int capture_wait(void* state)
 {
     vtcapture_backend_state_t* self = (vtcapture_backend_state_t*)state;
     uint32_t attempt_count = 0;
+    int ret = 0;
 
     // wait until buffer address changed
     while (!self->terminate) {
-        if (vtCapture_currentCaptureBuffInfo(self->driver, &self->buff) != 0) {
+        if ((ret = vtCapture_currentCaptureBuffInfo(self->driver, &self->buff)) == 17) {
 
-            ERR("vtCapture_currentCaptureBuffInfo() failed.");
+            ERR("vtCapture_currentCaptureBuffInfo() failed: %d", ret);
+            //Quirk
+            if (self->quirk_force_capture) {
+                int fd;
+        
+                DBG("Quirk enabled. Open /dev/forcecapture");
+                fd = open("/dev/forcecapture", O_RDWR);
+                if(fd < 0) {
+                        ERR("Can't open /dev/forcecapture!");
+                        return -2;
+                }
+        
+                INFO("QUIRK_VTCAPTURE_FORCE_CAPTURE: Calling interface with FC_K6HP");
+                ioctl(fd, FC_K6HP); 
+        
+                DBG("Closing /dev/forcecapture");
+                close(fd);
+
+                return -99; //Restart video capture
+            }
+            return -1;
+        } else if (ret != 0) {
+
+            ERR("vtCapture_currentCaptureBuffInfo() failed: %d", ret);
             return -1;
         }
 
@@ -221,7 +274,7 @@ int capture_wait(void* state)
         if (attempt_count >= 1000000 / 100) {
             // Prevent hanging...
             WARN("captureCurrentBuffInfo() never returned a new plane!");
-            return 1;
+            return -99; //Restart video capture
         }
         usleep(100);
     }

--- a/src/quirks.h
+++ b/src/quirks.h
@@ -11,5 +11,9 @@ enum CAPTURE_QUIRKS {
        DILE_VT_SetVideoFrameOutputDeviceDumpLocation and
        DILE_VT_SetVideoFrameOutputDeviceOutputRegion
     */
-    QUIRK_DILE_VT_DUMP_LOCATION_2 = 0x4
+    QUIRK_DILE_VT_DUMP_LOCATION_2 = 0x4,
+    
+    //vtCapture
+    // Reenables video capture using custom kernel module
+    QUIRK_VTCAPTURE_FORCE_CAPTURE = 0x100
 };

--- a/src/service.c
+++ b/src/service.c
@@ -468,21 +468,25 @@ static bool picture_callback(LSHandle* sh __attribute__((unused)), LSMessage* ms
 int service_register(service_t* service, GMainLoop* loop)
 {
     LSHandle* handle = NULL;
+    LSHandle* handlelegacy = NULL;
     LSError lserror;
 
     LSErrorInit(&lserror);
 
+    bool registeredLegacy = false;
     bool registered = false;
 
-    if (&LSRegisterPubPriv != 0) {
-        DBG("Using LSRegisterPubPriv");
-        registered = LSRegisterPubPriv(SERVICE_NAME, &handle, true, &lserror);
+     if (&LSRegisterPubPriv != 0) {
+        DBG("Try register on LSRegister");
+        registered = LSRegister(SERVICE_NAME, &handle, &lserror);
+        DBG("Try legacy register on LSRegisterPubPriv");
+        registeredLegacy = LSRegisterPubPriv(SERVICE_NAME, &handlelegacy, true, &lserror);
     } else {
-        DBG("Using LSRegister");
+        DBG("Try register on LSRegister");
         registered = LSRegister(SERVICE_NAME, &handle, &lserror);
     }
 
-    if (!registered) {
+    if (!registered && !registeredLegacy) {
         ERR("Unable to register on Luna bus: %s", lserror.message);
         LSErrorFree(&lserror);
         return -1;
@@ -503,6 +507,24 @@ int service_register(service_t* service, GMainLoop* loop)
 
     if (!LSCall(handle, "luna://com.webos.settingsservice/getSystemSettings", "{\"category\":\"picture\",\"subscribe\":true}", picture_callback, (void*)service, NULL, &lserror)) {
         WARN("settingsservice/getSystemSettings call failed: %s", lserror.message);
+    }
+
+    if (registeredLegacy){
+        LSRegisterCategory(handlelegacy, "/", methods, NULL, NULL, &lserror);
+        LSCategorySetData(handlelegacy, "/", service, &lserror);
+        LSGmainAttach(handlelegacy, loop, &lserror);
+
+        if (!LSCall(handlelegacy, "luna://com.webos.service.tvpower/power/getPowerState", "{\"subscribe\":true}", power_callback, (void*)service, NULL, &lserror)) {
+            WARN("Power state monitoring call failed: %s", lserror.message);
+        }
+
+        if (!LSCall(handlelegacy, "luna://com.webos.service.videooutput/getStatus", "{\"subscribe\":true}", videooutput_callback, (void*)service, NULL, &lserror)) {
+            WARN("videooutput/getStatus call failed: %s", lserror.message);
+        }
+
+        if (!LSCall(handlelegacy, "luna://com.webos.settingsservice/getSystemSettings", "{\"category\":\"picture\",\"subscribe\":true}", picture_callback, (void*)service, NULL, &lserror)) {
+            WARN("settingsservice/getSystemSettings call failed: %s", lserror.message);
+        }
     }
 
     LSErrorFree(&lserror);

--- a/src/unicapture.c
+++ b/src/unicapture.c
@@ -86,7 +86,11 @@ void* unicapture_vsync_handler(void* data)
 
     while (this->vsync_thread_running) {
         if (this->vsync && this->video_capture_running && this->video_capture->wait) {
-            this->video_capture->wait(this->video_capture->state);
+            if ((this->video_capture->wait(this->video_capture->state)) == -99){  //stop video capture (will be started again in unicapture_run())
+                INFO("Stopping video capture.");
+                this->video_capture->terminate(this->video_capture->state);
+                this->video_capture_running = false;
+            }
         } else {
             usleep(1000000 / (this->fps == 0 ? 30 : this->fps));
         }


### PR DESCRIPTION
Needs to merged after https://github.com/webosbrew/hyperion-webos/pull/83

`LSRegisterPubPriv()` is available, but not usable on some TVs. This PR will fix this issue.

In some situations vtCapture isn't fully available at start, which causes hanging video capture. This fix will restart capture in such situations.