### PR TITLE
Bring back NDK toolchain because of performance issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,6 @@ name: Build
 on:
   push:
 
-env:
-  TOOLCHAIN_URL: https://github.com/openlgtv/buildroot-nc4/releases/download/webos-9f5b1a1/arm-webos-linux-gnueabi_sdk-buildroot.tar.gz
-  TOOLCHAIN_SHA256: de49688d9d04bd533da59beb9a21e940203b95cc6ad4958858273b53502eb99b
-  TOOLCHAIN_DIR: /opt/arm-webos-linux-gnueabi_sdk-buildroot
-  TOOLCHAIN_FILE: /opt/arm-webos-linux-gnueabi_sdk-buildroot/share/buildroot/toolchainfile.cmake
-
 jobs:
   build-native-component:
     strategy:
@@ -23,17 +17,14 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
-    - name: Download and unpack toolchain
-      working-directory: /opt
-      run: |
-        wget -q -O toolchain.tar.gz ${TOOLCHAIN_URL}
-        echo "${TOOLCHAIN_SHA256} toolchain.tar.gz"|sha256sum -c -
-        tar xf toolchain.tar.gz
+    - name: Download webOS NDK
+      run: wget -q https://github.com/webosbrew/meta-lg-webos-ndk/releases/download/1.0.g-rev.5/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh -P ${{github.workspace}}/temp
 
-    - name: Relocate toolchain
-      working-directory: ${{ env.TOOLCHAIN_DIR }}
-      run: |
-        ./relocate-sdk.sh
+    - name: Install webOS NDK
+      run: chmod 755 ${{github.workspace}}/temp/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh && sudo ${{github.workspace}}/temp/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh -y
+
+    - name: Initialize NDK Environments
+      run: env -i bash -c '. /opt/webos-sdk-x86_64/1.0.g/environment-setup-armv7a-neon-webos-linux-gnueabi && env' >> $GITHUB_ENV
 
     - name: CMake Version
       run: cmake --version
@@ -44,7 +35,7 @@ jobs:
     - name: Build component
       working-directory: ${{github.workspace}}/build
       shell: bash
-      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_FILE .. && make hyperion-webos gm_backend halgal_backend dile_vt_backend vtcapture_backend
+      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} .. && make hyperion-webos gm_backend halgal_backend dile_vt_backend vtcapture_backend
 
     - name: List files
       run: find .


### PR DESCRIPTION
Fixes very slow performance on all TVs. 
Kind of addresses this issue: https://github.com/webosbrew/hyperion-webos/issues/94. But we should not close it yet, because renicing process might be still useful.
Tested on TVs down to webOS 3.4
