### PR TITLE
QUIRK: Fix quickstart on webOS 3.x TVs QUIRK_DILE_VT_DESTROY_ON_STOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Currently the following ones exist:
 | DILE_VT   | QUIRK_DILE_VT_CREATE_EX | Use `DILE_VT_CreateEx` instead of `DILE_VT_Create`  | 0x1  |
 | DILE_VT   | QUIRK_DILE_VT_NO_FREEZE_CAPTURE | Do not freeze frame before capturing (higher fps) | 0x2 |
 | DILE_VT   | QUIRK_DILE_VT_DUMP_LOCATION_2   | (webOS 3.4) Use undocumented dump location 2 | 0x4  |
+| DILE_VT   | QUIRK_DILE_VT_DESTROY_ON_STOP   | (webOS 3.4) Destroy driver on stop | 0x8  |
 | VTCAPTURE   | QUIRK_VTCAPTURE_FORCE_CAPTURE   | Use of a custom kernel module for reenable capture in special situation | 0x100  |
 
 

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -35,7 +35,8 @@ typedef struct _dile_vt_backend_state {
 
 int dile_init(void* state);
 
-int dile_init(void* state){
+int dile_init(void* state)
+{
     int ret = 0;
 
     dile_vt_backend_state_t* this = (dile_vt_backend_state_t*)state;
@@ -214,7 +215,7 @@ int capture_init(cap_backend_config_t* config, void** state_p)
 
     this->create_ex = HAS_QUIRK(config->quirks, QUIRK_DILE_VT_CREATE_EX);
     this->destroy_on_stop = HAS_QUIRK(config->quirks, QUIRK_DILE_VT_DESTROY_ON_STOP);
-    
+
     if (HAS_QUIRK(config->quirks, QUIRK_DILE_VT_NO_FREEZE_CAPTURE)) {
         INFO("[QUIRK_DILE_VT_NO_FREEZE_CAPTURE]: Won't freeze for acquiring frames");
         this->no_freeze_to_acquire_frame = true;
@@ -257,7 +258,7 @@ int capture_terminate(void* state)
 
     DILE_VT_Stop(this->vth);
 
-    if (this->destroy_on_stop){
+    if (this->destroy_on_stop) {
         DILE_VT_Destroy(this->vth);
     }
 

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -240,11 +240,11 @@ int capture_cleanup(void* state)
 int capture_start(void* state)
 {
     dile_vt_backend_state_t* this = (dile_vt_backend_state_t*)state;
-    if (DILE_VT_Start(this->vth) != 0 && this->destroy_on_stop) {
+    if ((ret = DILE_VT_Start(this->vth) != 0) && this->destroy_on_stop) {
         // May need to reinit
         dile_init(this);
         return -99;
-    } else {
+    } else if (ret != 0) {
         return -1;
     }
     return 0;

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -240,6 +240,7 @@ int capture_cleanup(void* state)
 int capture_start(void* state)
 {
     dile_vt_backend_state_t* this = (dile_vt_backend_state_t*)state;
+    int ret;
     if ((ret = DILE_VT_Start(this->vth) != 0) && this->destroy_on_stop) {
         // May need to reinit
         dile_init(this);

--- a/src/quirks.h
+++ b/src/quirks.h
@@ -12,6 +12,12 @@ enum CAPTURE_QUIRKS {
        DILE_VT_SetVideoFrameOutputDeviceOutputRegion
     */
     QUIRK_DILE_VT_DUMP_LOCATION_2 = 0x4,
+    /*  (WebOS 3.x) Destroy DILE_VT driver on stop, so it can
+        be initialized again on TV standby awake. - TV will
+        kill hyperion-webos on standby, so driver is left in
+        memory
+    */
+    QUIRK_DILE_VT_DESTROY_ON_STOP = 0x8,
 
     // vtCapture
     // Reenables video capture using custom kernel module

--- a/src/unicapture.c
+++ b/src/unicapture.c
@@ -145,10 +145,13 @@ void* unicapture_run(void* data)
 
         if ((now - last_video_start) > 1000000 && video_capture != NULL && !this->video_capture_running) {
             last_video_start = now;
+            int ret;
             DBG("Attempting video capture init...");
-            if (video_capture->start(video_capture->state) == 0) {
+            if ((ret = video_capture->start(video_capture->state)) == 0) {
                 INFO("Video capture started");
                 this->video_capture_running = true;
+            } else if (ret == -99) {
+                this->video_capture_running = false;
             }
         }
 


### PR DESCRIPTION
In latest unicapture changes, we have changed how TVs powerstate is processed. In older versions we have used to completly stop capture on standby. Now we only stop capture and let capture interfaces in memory. 
The problem with older webOS TVs is, that in standby it regardless kills `hyperion-webos` after awake, which leads to not fully shut down capture interfaces and because of that a new interface can't be created. 

This PR will introduce another quirk `QUIRK_DILE_VT_DESTROY_ON_STOP`, which will destroy DILE_VT interface, when a standby is in progress, so it can be created on next TV awake, without the need of disabling QuickStart+ or completly reboot TV.

This addresses https://github.com/webosbrew/hyperion-webos/issues/95

@tuxuser Can you please review?
