### PR TITLE
LUT mapping

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@ static struct option long_options[] = {
     { "no-vsync", no_argument, 0, 'n' },
     { "no-hdr", no_argument, 0, 'r' },
     { "no-powerstate", no_argument, 0, 's' },
+    { "lut-table", required_argument, 0, 't' },
     { "backend", required_argument, 0, 'b' },
     { "ui-backend", required_argument, 0, 'u' },
     { "quirks", required_argument, 0, 'q' },
@@ -62,6 +63,7 @@ static void print_usage()
     printf("  -n, --no-vsync        Disable vsync (may increase framerate at the cost of tearing/artifacts)\n");
     printf("  -r, --no-hdr          Disable automatic HDR mode switching\n");
     printf("  -s, --no-powerstate   Disable automatic powerstate switching\n");
+    printf("  -t, --lut-table=FILE  LUT table file\n");
     printf("  -q, --quirks=QUIRKS   Enable certain handling for per-device quirks\n");
     printf("  -c, --config=PATH     Absolute path for configfile to load settings. Giving additional runtime arguments will overwrite loaded ones.\n");
     printf("  -d, --dump-frames     Dump raw video frames to /tmp/.\n");
@@ -76,7 +78,7 @@ static int parse_options(int argc, char* argv[])
     int opt, longindex;
     int ret;
 
-    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:u:q:c:lvnhdVGrs", long_options, &longindex)) != -1) {
+    while ((opt = getopt_long(argc, argv, "x:y:a:p:f:b:u:q:c:t:lvnhdVGrs", long_options, &longindex)) != -1) {
         switch (opt) {
         case 'x':
             settings.width = atoi(optarg);
@@ -128,6 +130,10 @@ static int parse_options(int argc, char* argv[])
             break;
         case 'q':
             settings.quirks = atoi(optarg);
+            break;
+        case 't':
+            free(settings.lut_table);
+            settings.lut_table = strdup(optarg);
             break;
         case 'c':
             DBG("Loading config file %s...", optarg);

--- a/src/service.c
+++ b/src/service.c
@@ -84,6 +84,8 @@ int service_init(service_t* service, settings_t* settings)
     service->unicapture.callback_data = (void*)service;
     service->unicapture.dump_frames = settings->dump_frames;
 
+    unicapture_load_lut_table(&service->unicapture, settings->lut_table);
+
     char* ui_backends[] = { "libgm_backend.so", "libhalgal_backend.so", NULL };
     char* video_backends[] = { "libvtcapture_backend.so", "libdile_vt_backend.so", NULL };
     char backend_name[FILENAME_MAX] = { 0 };

--- a/src/settings.c
+++ b/src/settings.c
@@ -16,6 +16,8 @@ void settings_init(settings_t* settings)
     settings->height = 180;
     settings->quirks = 0;
 
+    settings->lut_table = strdup("");
+
     settings->no_video = false;
     settings->no_gui = false;
     settings->autostart = false;
@@ -58,6 +60,13 @@ int settings_load_json(settings_t* settings, jvalue_ref source)
     if ((value = jobject_get(source, j_cstr_to_buffer("unix-socket"))) && jis_boolean(value))
         jboolean_get(value, &settings->unix_socket);
 
+    if ((value = jobject_get(source, j_cstr_to_buffer("lut-table"))) && jis_string(value)) {
+        free(settings->lut_table);
+        raw_buffer str = jstring_get(value);
+        settings->lut_table = strdup(str.m_str);
+        jstring_free_buffer(str);
+    }
+
     if ((value = jobject_get(source, j_cstr_to_buffer("fps"))) && jis_number(value))
         jnumber_get_i32(value, &settings->fps);
     if ((value = jobject_get(source, j_cstr_to_buffer("width"))) && jis_number(value))
@@ -93,6 +102,8 @@ int settings_save_json(settings_t* settings, jvalue_ref target)
     jobject_set(target, j_cstr_to_buffer("port"), jnumber_create_i32(settings->port));
     jobject_set(target, j_cstr_to_buffer("priority"), jnumber_create_i32(settings->priority));
     jobject_set(target, j_cstr_to_buffer("unix-socket"), jboolean_create(settings->unix_socket));
+
+    jobject_set(target, j_cstr_to_buffer("lut-table"), jstring_create(settings->lut_table));
 
     jobject_set(target, j_cstr_to_buffer("fps"), jnumber_create_i32(settings->fps));
     jobject_set(target, j_cstr_to_buffer("width"), jnumber_create_i32(settings->width));

--- a/src/settings.h
+++ b/src/settings.h
@@ -22,6 +22,8 @@ typedef struct _settings_t {
     bool vsync;
     int quirks;
 
+    char* lut_table;
+
     bool no_video;
     bool no_gui;
 

--- a/src/unicapture.h
+++ b/src/unicapture.h
@@ -102,6 +102,8 @@ typedef struct _unicapture_state {
     struct {
         double framerate;
     } metrics;
+
+    uint8_t* lut_table;
 } unicapture_state_t;
 
 #ifdef __cplusplus
@@ -112,6 +114,7 @@ int unicapture_try_backends(cap_backend_config_t* config, capture_backend_t* bac
 int unicapture_init_backend(cap_backend_config_t* config, capture_backend_t* backend, char* name);
 int unicapture_start(unicapture_state_t* state);
 int unicapture_stop(unicapture_state_t* state);
+int unicapture_load_lut_table(unicapture_state_t* state, char* lut_table_file);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR aims at solving the color accuracy issues seen with the LG capture APIs. Essentially, this is like HyperHDR's HDR tone mapping feature but integrated into hyperion-webos itself. The data format is also the same and as such lut tables from HyperHDR can be used as is. However, opposed to HyperHDR the tone mapping is always active because we are seeing color inaccuraries even on SDR content.

I am providing my LUT file that I calculated using machine learning by showing pregenerated color table images and capturing them. Then the network learned given an input capture color to predict the input color. The predictions were carried out for the full 8-bit color space and saved into a LUT file. The generated LUT is not perfect for many reasons possibly the most prominent one being that multiple input colors match the same captured color. Yet still, without LUT mapping colors are quite off. For instance, solid red captures as [228, 80, 52], green as [110, 255, 100] and blue as [44, 0, 184] which is quite far off the real value.

I am marking this as WIP because I haven't tested configuration reloading.

[LUT table](http://transfer.sh/bOqQG3/flat_lut_lin_tables.3d)