### PR TITLE
Download external libyuv-project using DOWNLOAD_URL option

### DIFF
--- a/libyuv/CMakeLists.txt
+++ b/libyuv/CMakeLists.txt
@@ -2,8 +2,8 @@ include(ExternalProject)
 
 ExternalProject_Add(
   libyuv
-  URL https://chromium.googlesource.com/libyuv/libyuv/+archive/fdc71956bdade0012b0628b5011b567c06c72308.tar.gz
-  DOWNLOAD_COMMAND wget https://chromium.googlesource.com/libyuv/libyuv/+archive/fdc71956bdade0012b0628b5011b567c06c72308.tar.gz -O - | tar xz -C <DOWNLOAD_DIR>/libyuv
+  GIT_REPOSITORY https://chromium.googlesource.com/libyuv/libyuv
+  GIT_TAG fdc71956bdade0012b0628b5011b567c06c72308
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_C_FLAGS=${COMMON_FLAGS}

--- a/libyuv/CMakeLists.txt
+++ b/libyuv/CMakeLists.txt
@@ -3,6 +3,7 @@ include(ExternalProject)
 ExternalProject_Add(
   libyuv
   URL https://chromium.googlesource.com/libyuv/libyuv/+archive/fdc71956bdade0012b0628b5011b567c06c72308.tar.gz
+  DOWNLOAD_COMMAND wget https://chromium.googlesource.com/libyuv/libyuv/+archive/fdc71956bdade0012b0628b5011b567c06c72308.tar.gz -O - | tar xz -C <DOWNLOAD_DIR>/libyuv
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_C_FLAGS=${COMMON_FLAGS}


### PR DESCRIPTION
Download of libyuv tar really often fails during first project build phase, because used curl for source.tar download doesn't seem to support https.
This PR works around this problem using the `DOWNLOAD_COMMAND` option. 

@tuxuser Don't know if this is the straight way to fix this issue. Maybe you can leave a comment.

