### PR TITLE
vtc: add dump loc 1 quirk

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Currently the following ones exist:
 | DILE_VT   | QUIRK_DILE_VT_NO_FREEZE_CAPTURE | Do not freeze frame before capturing (higher fps) | 0x2 |
 | DILE_VT   | QUIRK_DILE_VT_DUMP_LOCATION_2   | (webOS 3.4) Use undocumented dump location 2 | 0x4  |
 | VTCAPTURE   | QUIRK_VTCAPTURE_FORCE_CAPTURE   | Use of a custom kernel module for reenable capture in special situation | 0x100  |
+| VTCAPTURE   | QUIRK_VTCAPTURE_DUMP_LOCATION_1   | Use undocumented dump location 1, may provide better colors on some models | 0x200  |
 
 
 They can be provided in `config.json` via the `{"quirks": 0}` field or on commandline via `--quirks`.

--- a/src/quirks.h
+++ b/src/quirks.h
@@ -15,5 +15,8 @@ enum CAPTURE_QUIRKS {
 
     // vtCapture
     // Reenables video capture using custom kernel module
-    QUIRK_VTCAPTURE_FORCE_CAPTURE = 0x100
+    QUIRK_VTCAPTURE_FORCE_CAPTURE = 0x100,
+
+    // Capture frames at V4L2_EXT_CAPTURE_SCALER_INPUT = 1 (before V4L2_EXT_CAPTURE_SCALER_OUTPUT = 2)
+    QUIRK_VTCAPTURE_DUMP_LOCATION_1 = 0x200,
 };


### PR DESCRIPTION
On some tv-s (including my A1/lm21u/mt5889) dumped frames from scaler output affected by picture settings. Dumping from scaler input gives perfect color for builtin apps, however it breaks hdmi tonemapping afaik. (havent tried due to lack of hdmi device)

**dump loc 2 (original):**
![image](https://user-images.githubusercontent.com/237259/224553748-a2dc2126-8a3f-4338-8917-71ffd858960f.png)
**dump loc 1:**
![image](https://user-images.githubusercontent.com/237259/224553732-1fbb1956-ad3f-4dd3-9e83-7fe69caff0dc.png)

**original:**
![image](https://user-images.githubusercontent.com/237259/224554132-a7e72870-bdc6-471d-a867-ebe65712f6f9.png)

Credits to @sundermann for finding it.