### PR TITLE
don't send invalid (black) frames to hyperion

### DIFF
--- a/src/unicapture.c
+++ b/src/unicapture.c
@@ -263,7 +263,7 @@ void* unicapture_run(void* data)
             INFO("Buffer dumped to: %s", filename);
         }
 
-        if (this->callback != NULL) {
+        if (got_frame && this->callback != NULL) {
             this->callback(this->callback_data, width, height, final_frame);
         }
 


### PR DESCRIPTION
It also causes massive cpu usage (e.g. without gui capture) since its in while (true) without sleep.