### PR TITLE
Fix pixel byte order / color correctness for vtcapture

### DIFF
--- a/src/backends/libgm.c
+++ b/src/backends/libgm.c
@@ -49,7 +49,7 @@ int capture_acquire_frame(void* state, frame_info_t* frame)
         return ret;
     }
 
-    frame->pixel_format = PIXFMT_ABGR;
+    frame->pixel_format = PIXFMT_ARGB;
     frame->width = width;
     frame->height = height;
     frame->planes[0].buffer = this->surface_info.framebuffer;

--- a/src/backends/libhalgal.c
+++ b/src/backends/libhalgal.c
@@ -128,7 +128,7 @@ int capture_acquire_frame(void* state, frame_info_t* frame)
         return ret;
     }
 
-    frame->pixel_format = PIXFMT_ABGR;
+    frame->pixel_format = PIXFMT_ARGB;
     frame->width = this->width;
     frame->height = this->height;
     frame->planes[0].buffer = this->mem_addr;

--- a/src/converter.c
+++ b/src/converter.c
@@ -36,7 +36,7 @@ int converter_run(converter_t* this, frame_info_t* input, frame_info_t* output, 
         output->planes[0].stride = output->width * 4;
 
         if (input->pixel_format == PIXFMT_RGB) {
-            RGB24ToARGB(
+            RAWToARGB(
                 input->planes[0].buffer,
                 input->planes[0].stride,
                 output->planes[0].buffer,
@@ -52,7 +52,7 @@ int converter_run(converter_t* this, frame_info_t* input, frame_info_t* output, 
                 output->width,
                 output->height);
         } else if (input->pixel_format == PIXFMT_YUV420_SEMI_PLANAR) {
-            NV21ToARGB(
+            NV12ToARGB(
                 input->planes[0].buffer,
                 input->planes[0].stride,
                 input->planes[1].buffer,
@@ -84,6 +84,9 @@ int converter_run(converter_t* this, frame_info_t* input, frame_info_t* output, 
                 output->planes[0].stride,
                 output->width,
                 output->height);
+        } else if (input->pixel_format == PIXFMT_ARGB) {
+            output->planes[0].buffer = input->planes[0].buffer;
+            output->planes[0].stride = input->planes[0].stride;
         } else {
             return -2;
         }

--- a/src/json_rpc_client.c
+++ b/src/json_rpc_client.c
@@ -65,13 +65,14 @@ int send_rpc_message(char* host, ushort rpc_port, jvalue_ref post_body_jval, jva
     JSchemaInfo schema;
 
     char* url = (char*)calloc(1, PATH_MAX);
+    char* response = (char*)calloc(1, MAX_RESPONSE_BUF_SZ);
+
     if (url == NULL) {
         ERR("send_rpc_message: alloc failed -> url");
         ret = -1;
         goto exit;
     }
 
-    char* response = (char*)calloc(1, MAX_RESPONSE_BUF_SZ);
     if (response == NULL) {
         ERR("send_rpc_message: alloc failed -> response");
         ret = -2;

--- a/src/unicapture.c
+++ b/src/unicapture.c
@@ -214,7 +214,7 @@ void* unicapture_run(void* data)
                 4 * width,
                 width,
                 height);
-            ARGBToRGB24(
+            ARGBToRAW(
                 blended_frame,
                 4 * width,
                 final_frame,
@@ -227,7 +227,7 @@ void* unicapture_run(void* data)
 
             final_frame = realloc(final_frame, width * height * 3);
 
-            ARGBToRGB24(
+            ARGBToRAW(
                 ui_frame_converted.planes[0].buffer,
                 ui_frame_converted.planes[0].stride,
                 final_frame,
@@ -240,7 +240,7 @@ void* unicapture_run(void* data)
 
             final_frame = realloc(final_frame, width * height * 3);
 
-            ARGBToRGB24(
+            ARGBToRAW(
                 video_frame_converted.planes[0].buffer,
                 video_frame_converted.planes[0].stride,
                 final_frame,


### PR DESCRIPTION
In libyuv RGB24 actually means bgr byte order. Hyperion/HyperHDR expect pixels to be in rgb byte order.

This wasn't really an issue with UI layer captures as:

Capture using `FMT_ABGR` (which is in fact ARGB) => ABGRToARGB (now the bytes are indeed bgr) => ARGBToRGB24 (reversing it again to get rgb again)

Though in case for the captured content from vtcapture we assumed it to be NV21 (which is in fact NV12, confirmed using kernel sources) it kind of works because NV21 uses a similar but swapped layout. However we end up with swapped UV planes resulting in the colors being a little bit off. If NV12 is used then colors are almost perfect.

Thanks @asturel for investigating this