### PR TITLE
Support an alternative dump location for vtcapture

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ In this case, to not need totally different binaries, we implemented *quirks*, w
 
 Currently the following ones exist:
 
-| Backend   | Quirk                   | Description                                         | Flag |
-| --------- | ----------------------- | --------------------------------------------------- | ---- |
-| DILE_VT   | QUIRK_DILE_VT_CREATE_EX | Use `DILE_VT_CreateEx` instead of `DILE_VT_Create`  | 0x1  |
-| DILE_VT   | QUIRK_DILE_VT_NO_FREEZE_CAPTURE | Do not freeze frame before capturing (higher fps) | 0x2 |
-| DILE_VT   | QUIRK_DILE_VT_DUMP_LOCATION_2   | (webOS 3.4) Use undocumented dump location 2 | 0x4  |
-| VTCAPTURE   | QUIRK_VTCAPTURE_FORCE_CAPTURE   | Use of a custom kernel module for reenable capture in special situation | 0x100  |
+| Backend           | Quirk                           | Description                                                             | Flag  |
+|-------------------|---------------------------------|-------------------------------------------------------------------------|-------|
+| DILE_VT           | QUIRK_DILE_VT_CREATE_EX         | Use `DILE_VT_CreateEx` instead of `DILE_VT_Create`                      | 0x1   |
+| DILE_VT           | QUIRK_DILE_VT_NO_FREEZE_CAPTURE | Do not freeze frame before capturing (higher fps)                       | 0x2   |
+| DILE_VT VTCAPTURE | QUIRK_ALTERNATIVE_DUMP_LOCATION | (webOS 3.4, VTCAPTURE) Use alternative dump location                    | 0x4   |
+| VTCAPTURE         | QUIRK_VTCAPTURE_FORCE_CAPTURE   | Use of a custom kernel module for reenable capture in special situation | 0x100 |
 
 
 They can be provided in `config.json` via the `{"quirks": 0}` field or on commandline via `--quirks`.

--- a/src/backends/libdile_vt.c
+++ b/src/backends/libdile_vt.c
@@ -65,7 +65,7 @@ int capture_init(cap_backend_config_t* config, void** state_p)
     DBG("input deinterlace: %d; display deinterlace: %d", limitation.supportInputVideoDeInterlacing, limitation.supportDisplayVideoDeInterlacing);
 
     DILE_VT_DUMP_LOCATION_TYPE_T dump_location;
-    if (HAS_QUIRK(config->quirks, QUIRK_DILE_VT_DUMP_LOCATION_2)) {
+    if (HAS_QUIRK(config->quirks, QUIRK_ALTERNATIVE_DUMP_LOCATION)) {
         // Quirk for WebOS 3.4 initialization
         INFO("[QUIRK_DILE_VT_DUMP_LOCATION_2]: Attempting UNDOCUMENTED dump location 2...");
         dump_location = 2;

--- a/src/backends/libvtcapture.cpp
+++ b/src/backends/libvtcapture.cpp
@@ -52,7 +52,7 @@ int capture_init(cap_backend_config_t* config, void** state_p)
 
     // Sorry, no unlimited fps for you.
     self->props.frm = config->fps == 0 ? 60 : config->fps;
-    self->props.dump = 2;
+    self->props.dump = HAS_QUIRK(config->quirks, QUIRK_ALTERNATIVE_DUMP_LOCATION) ? 1 : 2;
     self->props.loc.x = 0;
     self->props.loc.y = 0;
     self->props.reg.w = config->resolution_width;

--- a/src/quirks.h
+++ b/src/quirks.h
@@ -11,7 +11,7 @@ enum CAPTURE_QUIRKS {
        DILE_VT_SetVideoFrameOutputDeviceDumpLocation and
        DILE_VT_SetVideoFrameOutputDeviceOutputRegion
     */
-    QUIRK_DILE_VT_DUMP_LOCATION_2 = 0x4,
+    QUIRK_ALTERNATIVE_DUMP_LOCATION = 0x4,
 
     // vtCapture
     // Reenables video capture using custom kernel module


### PR DESCRIPTION
Supersedes #107

I don't think it makes sense to add another quirk which essentially does the same thing. Whilst it's true that there are more dump locations in the kernel, I never got these to work properly. The only reasonable alternative dump location for vtcapture seems to be at scaler input.

By reusing the existing quirk it's also easy to drop into an existing piccap installation.

This captures at scaler input but may not work properly on all SoCs. Has the benefit that the input on this location is before applying any image enhancement and thus can have lower latency and also more precise colors