### PR TITLE
Support for using different LUTs for SDR, HDR and DolbyVision

### DIFF
--- a/src/json_rpc_client.h
+++ b/src/json_rpc_client.h
@@ -16,4 +16,4 @@ const char* daemon_to_string(AmbientLightingDaemon flavor);
 int do_http_post(char* url, const char* post_body, char** response_body, int out_buf_sz);
 int send_rpc_message(char* host, ushort rpc_port, jvalue_ref post_body_jval, jvalue_ref* response_body_jval);
 int get_daemon_flavor(char* host, ushort rpc_port, AmbientLightingDaemon* flavor);
-int set_hdr_state(char* host, ushort rpc_port, bool hdr_active, char* custom_sdr_lut);
+int set_hdr_state(char* host, ushort rpc_port, const char* dynamic_range, bool sdr_tone_mapping);

--- a/src/json_rpc_client.h
+++ b/src/json_rpc_client.h
@@ -16,4 +16,4 @@ const char* daemon_to_string(AmbientLightingDaemon flavor);
 int do_http_post(char* url, const char* post_body, char** response_body, int out_buf_sz);
 int send_rpc_message(char* host, ushort rpc_port, jvalue_ref post_body_jval, jvalue_ref* response_body_jval);
 int get_daemon_flavor(char* host, ushort rpc_port, AmbientLightingDaemon* flavor);
-int set_hdr_state(char* host, ushort rpc_port, bool hdr_active);
+int set_hdr_state(char* host, ushort rpc_port, bool hdr_active, char* custom_sdr_lut);

--- a/src/service.c
+++ b/src/service.c
@@ -443,6 +443,7 @@ static bool videooutput_callback(LSHandle* sh __attribute__((unused)), LSMessage
     raw_buffer hdr_type_buf = jstring_get(hdr_type_ref);
     const char* hdr_type_str = hdr_type_buf.m_str;
 
+    // hdr_type_str: for DynamicRange or Dolby Vision it's 'dolbyHdr', for HDR it's 'hdr and for SDR it's 'none'
     if (strcmp(hdr_type_str, "none") == 0) {
         INFO("videooutput_callback: hdrType: %s --> SDR mode", hdr_type_str);
         hdr_enabled = false;
@@ -451,7 +452,7 @@ static bool videooutput_callback(LSHandle* sh __attribute__((unused)), LSMessage
         hdr_enabled = true;
     }
 
-    int ret = set_hdr_state(service->settings->unix_socket ? "127.0.0.1" : service->settings->address, RPC_PORT, hdr_enabled);
+    int ret = set_hdr_state(service->settings->unix_socket ? "127.0.0.1" : service->settings->address, RPC_PORT, hdr_enabled, service->settings->custom_sdr_lut);
     if (ret != 0) {
         ERR("videooutput_callback: set_hdr_state failed, ret: %d", ret);
     }
@@ -507,7 +508,7 @@ static bool picture_callback(LSHandle* sh __attribute__((unused)), LSMessage* ms
         hdr_enabled = true;
     }
 
-    int ret = set_hdr_state(service->settings->unix_socket ? "127.0.0.1" : service->settings->address, RPC_PORT, hdr_enabled);
+    int ret = set_hdr_state(service->settings->unix_socket ? "127.0.0.1" : service->settings->address, RPC_PORT, hdr_enabled, service->settings->custom_sdr_lut);
     if (ret != 0) {
         ERR("videooutput_callback: set_hdr_state failed, ret: %d", ret);
     }

--- a/src/settings.c
+++ b/src/settings.c
@@ -22,7 +22,8 @@ void settings_init(settings_t* settings)
     settings->vsync = true;
 
     settings->no_hdr = false;
-    settings->custom_sdr_lut = strdup("");
+    settings->sdr_tone_mapping = false;
+    settings->sdr_on_start = false;
     settings->no_powerstate = false;
 
     settings->dump_frames = false;
@@ -79,12 +80,10 @@ int settings_load_json(settings_t* settings, jvalue_ref source)
 
     if ((value = jobject_get(source, j_cstr_to_buffer("nohdr"))) && jis_boolean(value))
         jboolean_get(value, &settings->no_hdr);
-    if ((value = jobject_get(source, j_cstr_to_buffer("customsdrlut"))) && jis_string(value)) {
-        free(settings->custom_sdr_lut);
-        raw_buffer str = jstring_get(value);
-        settings->custom_sdr_lut = strdup(str.m_str);
-        jstring_free_buffer(str);
-    }
+    if ((value = jobject_get(source, j_cstr_to_buffer("sdrtonemapping"))) && jis_boolean(value))
+        jboolean_get(value, &settings->sdr_tone_mapping);
+    if ((value = jobject_get(source, j_cstr_to_buffer("sdronstart"))) && jis_boolean(value))
+        jboolean_get(value, &settings->sdr_on_start);
     if ((value = jobject_get(source, j_cstr_to_buffer("nopowerstate"))) && jis_boolean(value))
         jboolean_get(value, &settings->no_powerstate);
 
@@ -112,7 +111,8 @@ int settings_save_json(settings_t* settings, jvalue_ref target)
     jobject_set(target, j_cstr_to_buffer("autostart"), jboolean_create(settings->autostart));
 
     jobject_set(target, j_cstr_to_buffer("nohdr"), jboolean_create(settings->no_hdr));
-    jobject_set(target, j_cstr_to_buffer("customsdrlut"), jstring_create(settings->custom_sdr_lut));
+    jobject_set(target, j_cstr_to_buffer("sdrtonemapping"), jboolean_create(settings->sdr_tone_mapping));
+    jobject_set(target, j_cstr_to_buffer("sdronstart"), jboolean_create(settings->sdr_on_start));
     jobject_set(target, j_cstr_to_buffer("nopowerstate"), jboolean_create(settings->no_powerstate));
 
     return 0;

--- a/src/settings.c
+++ b/src/settings.c
@@ -22,6 +22,7 @@ void settings_init(settings_t* settings)
     settings->vsync = true;
 
     settings->no_hdr = false;
+    settings->custom_sdr_lut = strdup("");
     settings->no_powerstate = false;
 
     settings->dump_frames = false;
@@ -78,6 +79,12 @@ int settings_load_json(settings_t* settings, jvalue_ref source)
 
     if ((value = jobject_get(source, j_cstr_to_buffer("nohdr"))) && jis_boolean(value))
         jboolean_get(value, &settings->no_hdr);
+    if ((value = jobject_get(source, j_cstr_to_buffer("customsdrlut"))) && jis_string(value)) {
+        free(settings->custom_sdr_lut);
+        raw_buffer str = jstring_get(value);
+        settings->custom_sdr_lut = strdup(str.m_str);
+        jstring_free_buffer(str);
+    }
     if ((value = jobject_get(source, j_cstr_to_buffer("nopowerstate"))) && jis_boolean(value))
         jboolean_get(value, &settings->no_powerstate);
 
@@ -105,6 +112,7 @@ int settings_save_json(settings_t* settings, jvalue_ref target)
     jobject_set(target, j_cstr_to_buffer("autostart"), jboolean_create(settings->autostart));
 
     jobject_set(target, j_cstr_to_buffer("nohdr"), jboolean_create(settings->no_hdr));
+    jobject_set(target, j_cstr_to_buffer("customsdrlut"), jstring_create(settings->custom_sdr_lut));
     jobject_set(target, j_cstr_to_buffer("nopowerstate"), jboolean_create(settings->no_powerstate));
 
     return 0;

--- a/src/settings.h
+++ b/src/settings.h
@@ -30,6 +30,7 @@ typedef struct _settings_t {
     bool dump_frames;
 
     bool no_hdr;
+    char* custom_sdr_lut;
     bool no_powerstate;
 } settings_t;
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -30,7 +30,8 @@ typedef struct _settings_t {
     bool dump_frames;
 
     bool no_hdr;
-    char* custom_sdr_lut;
+    bool sdr_tone_mapping;
+    bool sdr_on_start;
     bool no_powerstate;
 } settings_t;
 


### PR DESCRIPTION
This PR uses HyperHDRs [custom LUT parameter](https://github.com/awawa-dev/HyperHDR/pull/334/commits/34887385f69c362bb634daa06111650c18244541) to allow automatically switching to different LUTs based on the dynamic range. The additional LUTs are fully optional, the default behavior is not changed.

### How to use?
Just add the additional LUTs to your LUT directory, e.g. `/home/pi/.hyperhdr/` and they will be used instead of the default LUT when the TV switches to the corresponding dynamic range. You only have to add the ones you need, HyperHDR will use the default LUT `lut_lin_tables.3d`, if the range specific one does not exist.

- HDR: `hdr_lut_lin_tables.3d`
- Dolby Vision: `dolbyHDR_lut_lin_tables.3d`
- SDR: `sdr_lut_lin_tables.3d`
  - To enable tone mapping for SDR content, the `sdr_tone_mapping` option must additionally be enabled in settings.

Additionally, it's now possible to automatically enable `sdr` mode during startup, by setting the `sdr_on_start` setting to true. 
(Otherwise, HyperHDR will start with its default setting, usually the default LUT or tone mapping disabled).

### Piccap support
This change goes in hand with my fork of piccap, which exposes these settings in its UI. 
I'll create a PR for it once this is merged. Preview of the changes: https://github.com/Dak0r/piccap/pull/1

#### Build
Here's a preview build of Piccap with these changes: 
[org.webosbrew.piccap_0.4.4_all.zip](https://github.com/user-attachments/files/16402741/org.webosbrew.piccap_0.4.4_all.zip)


### Related Issues
Issue https://github.com/webosbrew/hyperion-webos/issues/118
https://github.com/TBSniller/piccap/issues/73
There are likely more in the forums.
The SDR LUT also offers an alternative solution for PR https://github.com/webosbrew/hyperion-webos/pull/100

-----

#### Example SDR LUT
In case someone is interested: This is the SDR LUT I created by showing solid colors and adjusting the settings until the LED colors matched the screen. It's not perfect, but I've been using it for a year now -> [sdr_lut_lin_tables.zip - Extract with 7z!](https://github.com/user-attachments/files/16390943/sdr_lut_lin_tables.zip)
**Note:** It's a *.7z archive renamed to *.zip, so that it can be uploaded it as an attachment to Github (zip would be above the file size limit)

