### PR TITLE
Keep HDR always active

### DIFF
--- a/src/json_rpc_client.c
+++ b/src/json_rpc_client.c
@@ -199,7 +199,7 @@ int set_hdr_state(char* host, ushort rpc_port, DynamicRange range)
     jvalue_ref post_body = jobject_create();
 
     jobject_set(post_body, j_cstr_to_buffer("command"), jstring_create("videomodehdr"));
-    jobject_set(post_body, j_cstr_to_buffer("HDR"), jnumber_create_i32(range == SDR ? 0 : 1));
+    jobject_set(post_body, j_cstr_to_buffer("HDR"), jnumber_create_i32(1));
 
     const char* lut_filename = "";
     switch (range) {


### PR DESCRIPTION
According to https://github.com/awawa-dev/HyperHDR/pull/896#issuecomment-2525662688 this must always be enabled on webOS.