### PR TITLE
Make HDR check more robust

### DIFF
--- a/src/json_rpc_client.c
+++ b/src/json_rpc_client.c
@@ -27,7 +27,7 @@ DynamicRange get_dynamic_range(const char* range)
 {
     if (strcmp(range, "DolbyVision") == 0 || strcmp(range, "dolbyHdr") == 0) {
         return DOLBYVISION;
-    } else if (strcmp(range, "HDR") == 0 || strcmp(range, "HDR10") == 0 || strcmp(range, "hdr10") == 0 || strcmp(range, "hdr") == 0) {
+    } else if (strstr(range, "hdr") != NULL || strstr(range, "HDR") != NULL) {
         return HDR10;
     } else if (strcmp(range, "sdr") == 0 || strcmp(range, "none") == 0) {
         return SDR;


### PR DESCRIPTION
Fixes hdr ALLM format

Reported in https://github.com/TBSniller/piccap/issues/93#issuecomment-2675095106:
get_dynamic_range: Unknown dynamic range: hdrALLM