### PR TITLE
Handle socket timeouts as non error to prevent leds to turn off/on

### DIFF
--- a/src/hyperion_client.c
+++ b/src/hyperion_client.c
@@ -49,10 +49,16 @@ int hyperion_read()
         return -1;
     uint8_t headbuff[4];
     int n = read(sockfd, headbuff, 4);
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+        return 0;  // timeout is not an error, just no data yet
+    if (n < 0)
+        return -1;
     uint32_t messageSize = ((headbuff[0] << 24) & 0xFF000000) | ((headbuff[1] << 16) & 0x00FF0000) | ((headbuff[2] << 8) & 0x0000FF00) | ((headbuff[3]) & 0x000000FF);
-    if (n < 0 || messageSize >= sizeof(recvBuff))
+    if (messageSize >= sizeof(recvBuff))
         return -1;
     n = read(sockfd, recvBuff, messageSize);
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+        return 0;  // timeout is not an error, just no data yet
     if (n < 0)
         return -1;
     _parse_reply(hyperionnet_Reply_as_root(recvBuff));

--- a/src/hyperion_client.c
+++ b/src/hyperion_client.c
@@ -112,29 +112,35 @@ int hyperion_read()
     /* Phase 1: accumulate 4-byte header */
     if (rx.phase == RX_HEADER) {
         ret = _read_exact(sockfd, rx.header, 4, &rx.received);
-        if (ret < 0) return -1;
-        if (ret > 0) rx_last_data = time(NULL);
-        if (rx.received < 4) return _check_stale();
+        if (ret < 0)
+            return -1;
+        if (ret > 0)
+            rx_last_data = time(NULL);
+        if (rx.received < 4)
+            return _check_stale();
 
         rx.body_len = ((uint32_t)rx.header[0] << 24)
-                    | ((uint32_t)rx.header[1] << 16)
-                    | ((uint32_t)rx.header[2] <<  8)
-                    |  (uint32_t)rx.header[3];
+            | ((uint32_t)rx.header[1] << 16)
+            | ((uint32_t)rx.header[2] << 8)
+            | (uint32_t)rx.header[3];
 
         if (rx.body_len == 0 || rx.body_len >= sizeof(recvBuff)) {
             _rx_reset();
             return -1;
         }
 
-        rx.phase    = RX_BODY;
+        rx.phase = RX_BODY;
         rx.received = 0;
     }
 
     /* Phase 2: accumulate body */
     ret = _read_exact(sockfd, recvBuff, rx.body_len, &rx.received);
-    if (ret < 0) return -1;
-    if (ret > 0) rx_last_data = time(NULL);
-    if (rx.received < rx.body_len) return _check_stale();
+    if (ret < 0)
+        return -1;
+    if (ret > 0)
+        rx_last_data = time(NULL);
+    if (rx.received < rx.body_len)
+        return _check_stale();
 
     _parse_reply(hyperionnet_Reply_as_root(recvBuff));
     _rx_reset();

--- a/src/hyperion_client.c
+++ b/src/hyperion_client.c
@@ -26,7 +26,47 @@ static bool _registered = false;
 static int _priority = 0;
 static const char* _origin = NULL;
 static bool _connected = false;
-unsigned char recvBuff[1024];
+static unsigned char recvBuff[1024];
+
+enum rx_phase { RX_HEADER, RX_BODY };
+
+static struct {
+    enum rx_phase phase;
+    uint8_t       header[4];
+    uint32_t      body_len;
+    uint32_t      received;
+} rx;
+
+static void _rx_reset(void)
+{
+    memset(&rx, 0, sizeof(rx));
+}
+
+/**
+ * Try to read more bytes into buf (at offset *received, total needed: len).
+ * Returns:  >0  bytes read this call
+ *            0  EAGAIN/EWOULDBLOCK (non-fatal, try again later)
+ *           -1  fatal (EOF or real error)
+ * EINTR is retried internally.
+ */
+static int _read_exact(int fd, void* buf, size_t len, uint32_t* received)
+{
+    for (;;) {
+        ssize_t n = read(fd, (uint8_t*)buf + *received, len - *received);
+        if (n > 0) {
+            *received += (uint32_t)n;
+            return (int)n;
+        }
+        if (n == 0)
+            return 0; /* timeout or EOF — treat as transient */
+        /* n < 0 */
+        if (errno == EINTR)
+            continue;
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+            return 0;
+        return -1;
+    }
+}
 
 int hyperion_client(const char* origin, const char* hostname, int port, bool unix_socket, int priority)
 {
@@ -36,32 +76,50 @@ int hyperion_client(const char* origin, const char* hostname, int port, bool uni
     _registered = false;
     sockfd = 0;
 
+    int ret;
     if (unix_socket) {
-        return _connect_unix_socket(hostname);
+        ret = _connect_unix_socket(hostname);
     } else {
-        return _connect_inet_socket(hostname, port);
+        ret = _connect_inet_socket(hostname, port);
     }
+    _rx_reset();
+    return ret;
 }
 
 int hyperion_read()
 {
     if (!sockfd)
         return -1;
-    uint8_t headbuff[4];
-    int n = read(sockfd, headbuff, 4);
-    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
-        return 0;  // timeout is not an error, just no data yet
-    if (n < 0)
-        return -1;
-    uint32_t messageSize = ((headbuff[0] << 24) & 0xFF000000) | ((headbuff[1] << 16) & 0x00FF0000) | ((headbuff[2] << 8) & 0x0000FF00) | ((headbuff[3]) & 0x000000FF);
-    if (messageSize >= sizeof(recvBuff))
-        return -1;
-    n = read(sockfd, recvBuff, messageSize);
-    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
-        return 0;  // timeout is not an error, just no data yet
-    if (n < 0)
-        return -1;
+
+    int ret;
+
+    /* Phase 1: accumulate 4-byte header */
+    if (rx.phase == RX_HEADER) {
+        ret = _read_exact(sockfd, rx.header, 4, &rx.received);
+        if (ret < 0) return -1;
+        if (rx.received < 4) return 0; /* partial or EAGAIN */
+
+        rx.body_len = ((uint32_t)rx.header[0] << 24)
+                    | ((uint32_t)rx.header[1] << 16)
+                    | ((uint32_t)rx.header[2] <<  8)
+                    |  (uint32_t)rx.header[3];
+
+        if (rx.body_len == 0 || rx.body_len >= sizeof(recvBuff)) {
+            _rx_reset();
+            return -1;
+        }
+
+        rx.phase    = RX_BODY;
+        rx.received = 0;
+    }
+
+    /* Phase 2: accumulate body */
+    ret = _read_exact(sockfd, recvBuff, rx.body_len, &rx.received);
+    if (ret < 0) return -1;
+    if (rx.received < rx.body_len) return 0; /* partial or EAGAIN */
+
     _parse_reply(hyperionnet_Reply_as_root(recvBuff));
+    _rx_reset();
     return 0;
 }
 
@@ -71,6 +129,7 @@ int hyperion_destroy()
         return 0;
     close(sockfd);
     sockfd = 0;
+    _rx_reset();
     return 0;
 }
 

--- a/src/hyperion_client.c
+++ b/src/hyperion_client.c
@@ -31,13 +31,14 @@ static unsigned char recvBuff[1024];
 
 #define RX_STALE_SECS 120
 
-enum rx_phase { RX_HEADER, RX_BODY };
+enum rx_phase { RX_HEADER,
+    RX_BODY };
 
 static struct {
     enum rx_phase phase;
-    uint8_t       header[4];
-    uint32_t      body_len;
-    uint32_t      received;
+    uint8_t header[4];
+    uint32_t body_len;
+    uint32_t received;
 } rx;
 
 static time_t rx_last_data;

--- a/src/hyperion_client.c
+++ b/src/hyperion_client.c
@@ -11,6 +11,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "hyperion_reply_reader.h"
@@ -28,6 +29,8 @@ static const char* _origin = NULL;
 static bool _connected = false;
 static unsigned char recvBuff[1024];
 
+#define RX_STALE_SECS 120
+
 enum rx_phase { RX_HEADER, RX_BODY };
 
 static struct {
@@ -37,9 +40,12 @@ static struct {
     uint32_t      received;
 } rx;
 
+static time_t rx_last_data;
+
 static void _rx_reset(void)
 {
     memset(&rx, 0, sizeof(rx));
+    rx_last_data = time(NULL);
 }
 
 /**
@@ -66,6 +72,16 @@ static int _read_exact(int fd, void* buf, size_t len, uint32_t* received)
             return 0;
         return -1;
     }
+}
+
+static int _check_stale(void)
+{
+    if (difftime(time(NULL), rx_last_data) > RX_STALE_SECS) {
+        WARN("No data received for %d seconds, assuming stale connection", RX_STALE_SECS);
+        _rx_reset();
+        return -1;
+    }
+    return 0;
 }
 
 int hyperion_client(const char* origin, const char* hostname, int port, bool unix_socket, int priority)
@@ -97,7 +113,8 @@ int hyperion_read()
     if (rx.phase == RX_HEADER) {
         ret = _read_exact(sockfd, rx.header, 4, &rx.received);
         if (ret < 0) return -1;
-        if (rx.received < 4) return 0; /* partial or EAGAIN */
+        if (ret > 0) rx_last_data = time(NULL);
+        if (rx.received < 4) return _check_stale();
 
         rx.body_len = ((uint32_t)rx.header[0] << 24)
                     | ((uint32_t)rx.header[1] << 16)
@@ -116,7 +133,8 @@ int hyperion_read()
     /* Phase 2: accumulate body */
     ret = _read_exact(sockfd, recvBuff, rx.body_len, &rx.received);
     if (ret < 0) return -1;
-    if (rx.received < rx.body_len) return 0; /* partial or EAGAIN */
+    if (ret > 0) rx_last_data = time(NULL);
+    if (rx.received < rx.body_len) return _check_stale();
 
     _parse_reply(hyperionnet_Reply_as_root(recvBuff));
     _rx_reset();


### PR DESCRIPTION
Treat socket timeouts (EAGAIN/EWOULDBLOCK) as a non-error in hyperion_read(), returning 0 instead of -1. This prevents unnecessary disconnects when no data is available yet.

This fix was done by Claude 4.6

Instead of a timeout error where the leds go off shortly I only saw a small lag in Hyperion.NG live preview. Due to smoothing it wasnt even visible for me.

```
2026-03-30T20:41:04.387014Z [1894.501351000] user.debug hyperion-webos [] hyperion-webos DBGMSG {} unicapture_run: Framerate: 29.905573 FPS; timings - wait: 33533us, acquire: 88us, convert: 15us, process; 8us, send: 463us, release: 0us
2026-03-30T20:41:04.387104Z [1894.501434660] user.debug hyperion-webos [] hyperion-webos DBGMSG {} unicapture_run:         UI: pixfmt: 0; 0x0
2026-03-30T20:41:04.387147Z [1894.501478320] user.debug hyperion-webos [] hyperion-webos DBGMSG {} unicapture_run:      VIDEO: pixfmt: 2; 320x180
2026-03-30T20:41:04.387173Z [1894.501503500] user.debug hyperion-webos [] hyperion-webos DBGMSG {} unicapture_run: CONV    UI: pixfmt: 0; 0x0
2026-03-30T20:41:04.387196Z [1894.501526780] user.debug hyperion-webos [] hyperion-webos DBGMSG {} unicapture_run: CONV VIDEO: pixfmt: 2; 320x180
2026-03-30T20:41:06.392949Z [1896.507286520] user.debug hyperion-webos [] hyperion-webos DBGMSG {} unicapture_run: Framerate: 29.913967 FPS; timings - wait: 32784us, acquire: 1026us, convert: 13us, process; 9us, send: 444us, release: 1us
2026-03-30T20:41:06.393041Z [1896.507372200] user.debug hyperion-webos [] hyperion-webos DBGMSG {} unicapture_run:         UI: pixfmt: 0; 0x0
2026-03-30T20:41:06.393070Z [1896.507401280] user.debug hyperion-webos [] hyperion-webos DBGMSG {} unicapture_run:      VIDEO: pixfmt: 2; 320x180
2026-03-30T20:41:06.393094Z [1896.507425200] user.debug hyperion-webos [] hyperion-webos DBGMSG {} unicapture_run: CONV    UI: pixfmt: 0; 0x0
2026-03-30T20:41:06.393116Z [1896.507446600] user.debug hyperion-webos [] hyperion-webos DBGMSG {} unicapture_run: CONV VIDEO: pixfmt: 2; 320x180
```

In this log you can see acquire timing gone up to 1026 when i saw a short lag. I guess this created a error before this fix.
Instead of this change a Option to increase the timeout limit should also work for users with this problem.